### PR TITLE
Fix memory leak from EventEmitter

### DIFF
--- a/src/renderer/Layout.tsx
+++ b/src/renderer/Layout.tsx
@@ -140,17 +140,28 @@ export default function Layout() {
   */
   const { classes: styles } = useStyles();
 
-  /**
-   * Refresh handler.
-   */
-  ipc.on('refreshState', () => {
-    setState(prevState => {
-      return {
-        ...prevState, 
-        videoState: ipc.sendSync('getVideoState', categories)
-      }
-    })
-  });
+  // This is effectively equivalent to componentDidMount() in
+  // React Component classes
+  React.useEffect(() => {
+      /**
+       * Refresh handler.
+       */
+      ipc.on('refreshState', () => {
+        setState(prevState => {
+          return {
+            ...prevState,
+            videoState: ipc.sendSync('getVideoState', categories)
+          }
+        })
+      });
+    },
+    // From React documentation:
+    //
+    // > It's important to note the empty array as second argument for the
+    // > Effect Hook which makes sure to trigger the effect only on component
+    // > load (mount) and component unload (unmount).
+    []
+  );
 
   /**
    * Returns TSX for the tab buttons for category selection.


### PR DESCRIPTION
Fixes #86.

The listener on `ipc.on('refreshState')` was attached on every re-render, and this commit fixes that by making sure the listener only attached once per component load/unload.

This caused memory leaks as logged in the console:

```
(node:14384) MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 refreshState listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
```

`React.useEffect()` triggers on every state update, but when given an empty array as its 2nd argument, it changes that to only trigger on component load/unload.

The scenario is described in the React documentation here:

https://www.robinwieruch.de/react-function-component/#react-function-component-lifecycle

under section "React Function Component: Lifecycle".