### PR TITLE
Fix EventEmitter memory leak in settings

### DIFF
--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -96,9 +96,11 @@ export default function Settings() {
   /**
    * Event handler when user selects an option in dialog window.
    */
-  ipc.on('settingsWindow', (args: any) => {
-    if (args[0] === "pathSelected") setSetting(args);
-  });
+  React.useEffect(() => {
+    ipc.on('settingsWindow', (args: any) => {
+      if (args[0] === "pathSelected") setSetting(args);
+    });
+  }, []);
 
   return (
     <div className="container">


### PR DESCRIPTION
In the Settings window, if "**Run on Startup?**" is repeatedly clicked or if some other action causes redraw of the component, it would attach an event listener for `'settingsWindow'` on every redraw.

This caused a potential memory leak which this commit fixes.

Related to issue #86