### PR TITLE
Fix sizeMonitor() blocking the thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - [Issue 78](https://github.com/aza547/wow-recorder/issues/78) - Gracefully fail if a video can't be deleted, rather than giving an uncaught exception error
+- [Issue 75](https://github.com/aza547/wow-recorder/issues/75) - Fix size monitor blocking saving of videos.
 - [Issue 86](https://github.com/aza547/wow-recorder/issues/86) - Fix an event listener leak.
 - Fixed memory leak in EventEmitter attachment of listener for 'updateStatus'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "electron-updater": "^4.6.5",
         "fluent-ffmpeg": "^2.1.2",
         "fs": "^0.0.1-security",
+        "glob": "^7.2.0",
         "history": "^5.3.0",
         "obs-studio-node": "https://wowrecorder.blob.core.windows.net/wowrecorder/obs-studio-node-0.22.10-win64.tar.gz",
         "path": "^0.12.7",
@@ -4247,8 +4248,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4453,7 +4453,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5252,8 +5251,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -9155,8 +9153,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -9273,7 +9270,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10023,7 +10019,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12276,7 +12271,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -13124,7 +13118,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20496,8 +20489,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -20664,7 +20656,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -21274,8 +21265,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -24213,8 +24203,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -24300,7 +24289,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -24846,7 +24834,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -26536,7 +26523,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -27159,8 +27145,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "electron-updater": "^4.6.5",
     "fluent-ffmpeg": "^2.1.2",
     "fs": "^0.0.1-security",
-    "glob-promise": "^5.0.0",
+    "glob": "^8.0.3",
     "history": "^5.3.0",
     "obs-studio-node": "https://wowrecorder.blob.core.windows.net/wowrecorder/obs-studio-node-0.22.10-win64.tar.gz",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
     "electron-updater": "^4.6.5",
     "fluent-ffmpeg": "^2.1.2",
     "fs": "^0.0.1-security",
-    "glob": "^8.0.3",
+    "glob": "^7.2.0",
     "history": "^5.3.0",
     "obs-studio-node": "https://wowrecorder.blob.core.windows.net/wowrecorder/obs-studio-node-0.22.10-win64.tar.gz",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
     "electron-updater": "^4.6.5",
     "fluent-ffmpeg": "^2.1.2",
     "fs": "^0.0.1-security",
+    "glob-promise": "^5.0.0",
     "history": "^5.3.0",
     "obs-studio-node": "https://wowrecorder.blob.core.windows.net/wowrecorder/obs-studio-node-0.22.10-win64.tar.gz",
     "path": "^0.12.7",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -332,7 +332,7 @@ ipcMain.on('settingsWindow', (event, args) => {
         // need to create a recorder. If the config was previously
         // valid but has since changed, just do a reconfigure. 
         if (recorder) {
-          recorder.reconfigure(storageDir, monitorIndex);
+          recorder.reconfigure(storageDir, maxStorage, monitorIndex);
         } else {
           recorder = new Recorder(storageDir, maxStorage, monitorIndex);  
         }

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -213,8 +213,8 @@ const glob = require('glob');
             // finish up with the video file. Maybe this can be done better. 
             setTimeout(async () => {
                 const bufferedVideo = await getNewestVideo(this._bufferStorageDir);
-                await cutVideo(bufferedVideo, this._storageDir, metadata.duration);
-                writeMetadataFile(this._storageDir, metadata).then(resolve);
+                const videoPath = await cutVideo(bufferedVideo, this._storageDir, metadata.duration);
+                writeMetadataFile(videoPath, metadata).then(resolve);
             }, 
             2000)
         });   

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -255,7 +255,8 @@ const glob = require('glob');
     /**
      * Reconfigure the underlying obsRecorder. 
      */
-    reconfigure = (outputPath: string, monitorIndex: number) => {      
+    reconfigure = (outputPath: string, maxStorage: number, monitorIndex: number) => {
+        this._maxStorage = maxStorage;
 
         if (this._isRecording) {
             obsRecorder.stop();       

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -181,7 +181,10 @@ const glob = require('glob');
 
             // Run the size monitor to ensure we stay within size limit.
             // Need some maths to convert GB to bytes
-            runSizeMonitor(this._storageDir, this._maxStorage); 
+            runSizeMonitor(this._storageDir, this._maxStorage)
+                .then(() => {
+                    if (mainWindow) mainWindow.webContents.send('refreshState');
+                });
 
             // Clean-up the temporary recording directory. 
             this.cleanupBuffer();

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -209,10 +209,9 @@ const glob = require('glob');
             // It's a bit hacky that we async wait for 2 seconds for OBS to 
             // finish up with the video file. Maybe this can be done better. 
             setTimeout(async () => {
-                const bufferedVideo = getNewestVideo(this._bufferStorageDir);
+                const bufferedVideo = await getNewestVideo(this._bufferStorageDir);
                 await cutVideo(bufferedVideo, this._storageDir, metadata.duration);
-                writeMetadataFile(this._storageDir, metadata);  
-                resolve();       
+                writeMetadataFile(this._storageDir, metadata).then(resolve);
             }, 
             2000)
         });   

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -344,7 +344,7 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
         return files.shift().name;
      }
 
-     return Promise.reject('no files');
+     return Promise.reject('No video files were found while looking for the most recent video.');
 }  
 
 /**

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -24,11 +24,11 @@ const ffprobePath = fixPathWhenPackaged(require('@ffprobe-installer/ffprobe').pa
 const ffmpeg = require('fluent-ffmpeg');
 ffmpeg.setFfmpegPath(ffmpegPath);
 ffmpeg.setFfprobePath(ffprobePath);
-import fs from 'fs/promises';
-const fscb = require('fs')
+import { promises as fspromise } from 'fs';
+const fs = require('fs')
 import glob from 'glob-promise';
 
-let videoIndex: { [category: string]: number }  = {};
+let videoIndex: { [category: string]: number } = {};
 
 export let resolveHtmlPath: (htmlFileName: string) => string;
 
@@ -115,8 +115,8 @@ const loadAllVideos = (storageDir: any, videoState: any) => {
 const getMetadataForVideo = (video: string) => {
     const metadataFile = getMetadataFileForVideo(video)
 
-    if (fscb.existsSync(metadataFile)) {
-        const metadataJSON = fscb.readFileSync(metadataFile);
+    if (fs.existsSync(metadataFile)) {
+        const metadataJSON = fs.readFileSync(metadataFile);
         const metadata = JSON.parse(metadataJSON);
         return metadata;
     } else {
@@ -132,7 +132,7 @@ const saveMetadataForVideo = (videoPath: string, metadata: any) => {
     const metadataFile = getMetadataFileForVideo(videoPath);
 
     const newMetadataJsonString = JSON.stringify(metadata, null, 2);
-    fscb.writeFileSync(metadataFile, newMetadataJsonString);
+    fs.writeFileSync(metadataFile, newMetadataJsonString);
 }
 
 /**
@@ -269,14 +269,14 @@ const writeMetadataFile = async (storageDir: string, metadata: Metadata) => {
     const jsonString = JSON.stringify(metadata, null, 2);
     const metadataFileName = getMetadataFileForVideo(file);
 
-    return await fs.writeFile(metadataFileName, jsonString);
+    return await fspromise.writeFile(metadataFileName, jsonString);
 }    
 
 /**
  * Return information about a video needed for various parts of the application
  */
 const getVideoInfo = (videoPath: string): VideoInfo => {
-    const fstats = fscb.statSync(videoPath);
+    const fstats = fs.statSync(videoPath);
     const mtime = fstats.mtime;
     const size = fstats.size;
 
@@ -307,7 +307,7 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
     files = files.map((file: any) => {
         try {
             const metadataFileName = getMetadataFileForVideo(file.name);
-            const data = fscb.readFileSync(metadataFileName);
+            const data = fs.readFileSync(metadataFileName);
             const metadata = JSON.parse(data.toString());
             return { ...file, metadata, };
         } catch (e) {
@@ -366,7 +366,7 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
  const tryUnlinkSync = (file: string): boolean => {
     try {
         console.log("Deleting: " + file);
-        fscb.unlinkSync(file);
+        fs.unlinkSync(file);
         return true;
     } catch (e) {
         console.error(`Unable to delete file: ${file}.`)
@@ -386,7 +386,7 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
     }
 
     const metadataPath = getMetadataFileForVideo(videoPath);
-    if (fscb.existsSync(metadataPath)) {
+    if (fs.existsSync(metadataPath)) {
         tryUnlinkSync(metadataPath);
     }
 }  

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -125,6 +125,9 @@ const getMetadataForVideo = (video: string) => {
     }
 }
 
+/**
+ * Save metadata for the given video to disk
+ */
 const saveMetadataForVideo = (videoPath: string, metadata: any) => {
     const metadataFile = getMetadataFileForVideo(videoPath);
 
@@ -280,6 +283,10 @@ const getVideoInfo = (videoPath: string): VideoInfo => {
     return { name: videoPath, size, mtime };
 };
 
+/**
+ * Asynchronously find and return a list of video files in the given directory,
+ * sorted by modification time (newest to oldest)
+ */
 const getSortedVideos = async (storageDir: string): Promise<VideoInfo[]> => {
     const files = await glob(path.join(storageDir, "*.mp4"));
     return files
@@ -308,8 +315,6 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
         }
     });
 
-    let totalVideoFileSize = 0;
-
     // Filter files with metadata
     files = files.filter((file: any) => file && file.hasOwnProperty('metadata'));
 
@@ -318,6 +323,7 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
 
     // Filter files that doesn't cause the total video file size to exceed the maximum
     // as given by `maxStorageBytes`
+    let totalVideoFileSize = 0;
     files = files.filter((file: any) => {
         totalVideoFileSize += file.size;
         return totalVideoFileSize > maxStorageBytes;

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -303,11 +303,9 @@ const runSizeMonitor = async (storageDir: string, maxStorageGB: number): Promise
         return { ...file, metadata, };
     });
 
-    // Filter files with metadata
-    files = files.filter((file: any) => file && file.hasOwnProperty('metadata'));
-
-    // Filter files that aren't protected
-    files = files.filter((file: any) => !Boolean(file.metadata.protected));
+    // Consider files with NO metadata (dangling video files)
+    // and files that ARE NOT protected
+    files = files.filter((file: any) => !file.hasOwnProperty('metadata') || !Boolean(file.metadata.protected));
 
     // Filter files that doesn't cause the total video file size to exceed the maximum
     // as given by `maxStorageBytes`

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -25,8 +25,8 @@ const ffmpeg = require('fluent-ffmpeg');
 ffmpeg.setFfmpegPath(ffmpegPath);
 ffmpeg.setFfprobePath(ffprobePath);
 import { promises as fspromise } from 'fs';
-const fs = require('fs')
-import glob from 'glob-promise';
+import glob from 'glob';
+import fs from 'fs';
 
 let videoIndex: { [category: string]: number } = {};
 

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -117,14 +117,13 @@ const loadAllVideos = (storageDir: any, videoState: any) => {
 const getMetadataForVideo = (video: string) => {
     const metadataFile = getMetadataFileForVideo(video)
 
-    if (fs.existsSync(metadataFile)) {
-        const metadataJSON = fs.readFileSync(metadataFile);
-        const metadata = JSON.parse(metadataJSON);
-        return metadata;
-    } else {
+    if (!fs.existsSync(metadataFile)) {
         console.log("Metadata file does not exist: ", metadataFile);
         return undefined;
     }
+
+    const metadataJSON = fs.readFileSync(metadataFile);
+    return JSON.parse(metadataJSON.toString());
 }
 
 /**

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -24,9 +24,11 @@ const ffprobePath = fixPathWhenPackaged(require('@ffprobe-installer/ffprobe').pa
 const ffmpeg = require('fluent-ffmpeg');
 ffmpeg.setFfmpegPath(ffmpegPath);
 ffmpeg.setFfprobePath(ffprobePath);
+import util from 'util';
 import { promises as fspromise } from 'fs';
 import glob from 'glob';
 import fs from 'fs';
+const globPromise = util.promisify(glob)
 
 let videoIndex: { [category: string]: number } = {};
 
@@ -277,7 +279,7 @@ const writeMetadataFile = async (storageDir: string, metadata: Metadata) => {
  */
 const getVideoInfo = (videoPath: string): VideoInfo => {
     const fstats = fs.statSync(videoPath);
-    const mtime = fstats.mtime;
+    const mtime = fstats.mtime.getTime();
     const size = fstats.size;
 
     return { name: videoPath, size, mtime };
@@ -288,7 +290,7 @@ const getVideoInfo = (videoPath: string): VideoInfo => {
  * sorted by modification time (newest to oldest)
  */
 const getSortedVideos = async (storageDir: string): Promise<VideoInfo[]> => {
-    const files = await glob(path.join(storageDir, "*.mp4"));
+    const files = await globPromise(path.join(storageDir, "*.mp4"));
     return files
         .map(getVideoInfo)
         .sort((A: VideoInfo, B: VideoInfo) => B.mtime - A.mtime);


### PR DESCRIPTION
- Replace `glob` with `glob-promise` to be able to perform async globbing.

- Import `fs-promise` as `fs`and rename `fs` to `fscb` as `fs-promise` cannot be renamed on its import, as far as I know.

- Create async `getSortedVideos()` to find and return all video files sorted by modification time. This method will read all metadata for every video which by itself is a performance penalty, but considering modern hardware it should be neglible and not noticable.

- Remove `isVideoProtected()` as `getSortedVideos()` replace this.

- Create async `writeMetadataFile()` to reduce duplicate code.

- Refactor `deleteOldestVideo()` and `getNewestVideo()` to be async.

- Create `saveMetadataForVideo()`.

- Refactor `toggleVideoProtected()` to use `getMetadataForVideo()`/`saveMetadataForVideo()`.

This fixes #75 