### PR TITLE
Fixes cleanup errors if files are locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- [Issue 78](https://github.com/aza547/wow-recorder/issues/78) - Gracefully fail if a video can't be deleted, rather than giving an uncaught exception error
 - [Issue 86](https://github.com/aza547/wow-recorder/issues/86) - Fix an event listener leak.
 - Fixed memory leak in EventEmitter attachment of listener for 'updateStatus'
 

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -318,18 +318,35 @@ const deleteOldestVideo = (storageDir: any) => {
 }  
 
 /**
+ * Try to unlink a file and return a boolean indicating the success
+ * Logs any errors to the console, if the file couldn't be deleted for some reason.
+ */
+ const tryUnlinkSync = (file: string): boolean => {
+    try {
+        console.log("Deleting: " + file);
+        fs.unlinkSync(file);
+        return true;
+    } catch (e) {
+        console.error(`Unable to delete file: ${file}.`)
+        console.error((e as Error).message);
+        return false;
+    }
+ }
+
+/**
  * Delete a video and its metadata file if it exists. 
  */
  const deleteVideo = (videoPath: string) => {
-    const metadataPath = getMetadataFileForVideo(videoPath);
-
-    if (fs.existsSync(metadataPath)) {
-        console.log("Deleting: " + metadataPath);  
-        fs.unlinkSync(metadataPath);        
+    // If we can't delete the video file, make sure we don't delete the metadata
+    // file either, which would leave the video file dangling.
+    if (!tryUnlinkSync(videoPath)) {
+        return;
     }
 
-    console.log("Deleting: " + videoPath);
-    fs.unlinkSync(videoPath);
+    const metadataPath = getMetadataFileForVideo(videoPath);
+    if (fs.existsSync(metadataPath)) {
+        tryUnlinkSync(metadataPath);
+    }
 }  
 
 /**


### PR DESCRIPTION
If a video is open in another application, like VLC, and the application is closed - or if you attempt to delete that video - the app would throw an exception that we didn't catch.

This commit changes that so that we'll catch the error and log it to the console.
Fixes #78 
