### PR TITLE
Replace `string.split()` with `splitLogLine()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- [Issue 98](https://github.com/aza547/wow-recorder/issues/98) - Fix recording Mythic Keystone boss encounters before M+ feature has been implemented.
 - [Issue 78](https://github.com/aza547/wow-recorder/issues/78) - Gracefully fail if a video can't be deleted, rather than giving an uncaught exception error
 - [Issue 86](https://github.com/aza547/wow-recorder/issues/86) - Fix an event listener leak.
 - Fixed memory leak in EventEmitter attachment of listener for 'updateStatus'

--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -54,15 +54,19 @@ class LogLine {
      * Split the line by any delimiter that isn't a number
      */
     date (): Date {
-        const [month, day, hours, mins, secs, msec] = this.ts.split(/[^0-9]/, 6);
+        const timeParts = this.ts
+            .split(/[^0-9]/, 6)
+            .map(v => parseInt(v, 10))
+            .reverse();
+        const [msec, secs, mins, hours, day, month] = timeParts;
         const dateObj = new Date();
 
-        dateObj.setDate(parseInt(day, 10));
-        dateObj.setMonth(parseInt(month, 10));
-        dateObj.setHours(parseInt(hours, 10));
-        dateObj.setMinutes(parseInt(mins, 10));
-        dateObj.setSeconds(parseInt(secs, 10));
-        dateObj.setMilliseconds(parseInt(msec, 10))
+        if (day) dateObj.setDate(day);
+        if (month) dateObj.setMonth(month);
+        dateObj.setHours(hours);
+        dateObj.setMinutes(mins);
+        dateObj.setSeconds(secs);
+        dateObj.setMilliseconds(msec);
 
         return dateObj;
     }


### PR DESCRIPTION
### `splitLogLine`

Split log lines intelligently with respect to quotes, lists, tuples and what have we such that we can better use the data contained within the log lines.

`splitLogLine`  has a `maxSplits` argument that, when given, will limit the maximum number of parsed arguments returned. Technically, it's advisable to only parse up to as many arguments as needed, but that isn't done yet as that'd probably be a pre-emptive overoptimization.

The method now returns an instance of the new class `LogLine`, which contains both the timestamp and the line arguments. At the same time, all `handle*Line` methods have been updated to accept an argument of `LogLine` instead of a string.

`getCombatLogDate` has been moved to `LogLine` and simply called `date()`, all occurances of the former has been replaced by the latter.

This is not so much a performance improvement more than it's a logical grouping of methods/data.

### `handleLogLine`

`handleLogLine` has been refactored to use a `switch..case` style matching to avoid doing text searching with `string.contains()` for every line, which in a worst case scenario would perform this check as many times as there are `if`-conditions, which would be most of the time since we're only interested in a very limited subset of the combat log events that WoW logs.

`handleLogLine` now checks the line token type, like `COMBATANT_INFO` against an array of `interestingCombatLogEvents` and will only parse the full log line if one matches to improve the processing speed of combat events.

`handleRaid(Start|Stop)Line` has been renamed to `handleEncounter(Start|Stop)Line` as `ENCOUNTER_(START|STOP)` isn't exclusive to raids.