### PR TITLE
Fix: splitLogLine() max splits error and LogLine.date() off-by-one

### DIFF
--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -68,7 +68,7 @@ class LogLine {
         const dateObj = new Date();
 
         if (day) dateObj.setDate(day);
-        if (month) dateObj.setMonth(month);
+        if (month) dateObj.setMonth(month - 1);
         dateObj.setHours(hours);
         dateObj.setMinutes(mins);
         dateObj.setSeconds(secs);

--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -212,6 +212,9 @@ const splitLogLine = (line: string, maxSplits?: number): LogLine => {
         if (c === '\n') {
             break;
         }
+        if (maxSplits && args_list.length >= maxSplits) {
+            break;
+        }
 
         if (in_quote) {
             if (c === '"') {
@@ -226,9 +229,6 @@ const splitLogLine = (line: string, maxSplits?: number): LogLine => {
                     list_items.at(-1)?.push(value);
                 } else {
                     args_list.push(value);
-                    if (maxSplits && args_list.length >= maxSplits) {
-                        break;
-                    }
                 }
 
                 value = '';


### PR DESCRIPTION
Combat log line:

```log
9/15 20:46:15.096  ZONE_CHANGE,1195,"Iron Docks",23
```

Code:

```typescript
console.log(splitLogLine('9/15 20:46:15.096  ZONE_CHANGE,1195,"Iron Docks",23', 1));
```

Before change:

```js
LogLine {
  original: 'ZONE_CHANGE,1195,"Iron Docks",23',
  timestamp: '9/15 20:46:15.096',
  args: [
    'ZONE_CHANGE',
    'ZONE_CHANGE,1195',
    'ZONE_CHANGE,1195,Iron Docks',
    'ZONE_CHANGE,1195,Iron Docks,23'
  ]
}
```

After change:

```js
LogLine {
  original: 'ZONE_CHANGE,1195,"Iron Docks",23',
  timestamp: '9/15 20:46:15.096',
  args: [ 'ZONE_CHANGE' ]
}
```
