### PR TITLE
Cleanup the isUnitSelf() method

### DIFF
--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -2,6 +2,7 @@
 import { Combatant } from './combatant';
 import { recorder }  from './main';
 import { battlegrounds }  from './constants';
+import { UnitFlags } from './types';
 
 const tail = require('tail').Tail;
 const glob = require('glob');
@@ -576,13 +577,34 @@ function zoneChangeStop (line: LogLine): void {
 }
 
 /**
- * Determine if the srcFlags indicate a friendly unit.
- * @param srcFlags the srcFlags bitmask
- * @returns true if self; false otherwise. 
+ * Return whether the bitmask `flags` contain the bitmask `flag`
  */
-const isUnitSelf = (srcFlags: number): boolean => {
-    const masked = srcFlags & 0x511;
-    return masked === 0x511;
+const hasFlag = (flags: number, flag: number): boolean => {
+    return (flags & flag) !== 0;
+}
+
+/**
+ * Determine if the `flags` value indicate our own unit.
+ * This is determined by the unit being a player and having the
+ * flags `AFFILIATION_MINE` and `REACTION_FRIENDLY`.
+ */
+const isUnitSelf = (flags: number): boolean => {
+    return isUnitPlayer(flags) && (
+        hasFlag(flags, UnitFlags.REACTION_FRIENDLY) &&
+        hasFlag(flags, UnitFlags.AFFILIATION_MINE)
+    );
+}
+
+/**
+* Determine if the unit is a player.
+*
+* See more here: https://wowpedia.fandom.com/wiki/UnitFlag
+*/
+const isUnitPlayer = (flags: number): boolean => {
+    return (
+        hasFlag(flags, UnitFlags.CONTROL_PLAYER) &&
+        hasFlag(flags, UnitFlags.TYPE_PLAYER)
+    );
 }
 
 /**

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Application status
+ */
 enum AppStatus {
     WaitingForWoW,
     Recording,
@@ -6,6 +9,41 @@ enum AppStatus {
     SavingVideo,
 };
 
+/**
+ * Unit flags from combat log events
+ * See https://wowpedia.fandom.com/wiki/UnitFlag for more information
+ */
+ enum UnitFlags {
+    AFFILIATION_MINE = 0x00000001,
+    AFFILIATION_PARTY = 0x00000002,
+    AFFILIATION_RAID = 0x00000004,
+    AFFILIATION_OUTSIDER = 0x00000008,
+    AFFILIATION_MASK = 0x0000000F,
+    // Reaction
+    REACTION_FRIENDLY = 0x00000010,
+    REACTION_NEUTRAL = 0x00000020,
+    REACTION_HOSTILE = 0x00000040,
+    REACTION_MASK = 0x000000F0,
+    // Controller
+    CONTROL_PLAYER = 0x00000100,
+    CONTROL_NPC = 0x00000200,
+    CONTROL_MASK = 0x00000300,
+    // Type
+    TYPE_PLAYER = 0x00000400, // Units directly controlled by players.
+    TYPE_NPC = 0x00000800, // Units controlled by the server.
+    TYPE_PET = 0x00001000, // Pets are units controlled by a player or NPC, including via mind control.
+    TYPE_GUARDIAN = 0x00002000, // Units that are not controlled, but automatically defend their master.
+    TYPE_OBJECT = 0x00004000, // Objects are everything else, such as traps and totems.
+    TYPE_MASK = 0x0000FC00,
+    // Special cases (non-exclusive)
+    TARGET = 0x00010000,
+    FOCUS = 0x00020000,
+    MAINTANK = 0x00040000,
+    MAINASSIST = 0x00080000,
+    NONE = 0x80000000, // Whether the unit does not exist.
+    SPECIAL_MASK = 0xFFFF0000,
+  };
 export {
     AppStatus,
+    UnitFlags,
 }


### PR DESCRIPTION
- Add `enum UnitFlag` to types for easier identification of the various flags that a unit can have.

- Add `isUnitPlayer()` to easier identify a player controlled unit.

- Refactor `isUnitSelf()` to make use of `isUnitPlayer()` and `UnitFlags`.

To prove that nothing has change logically, the old `isUnitSelf()` method checked the flags against the hexadecimal value 0x511 which consists of the flags:
```typescript
UnitFlags.AFFILIATION_MINE = 1
UnitFlags.REACTION_FRIENDLY = 16
UnitFlags.CONTROL_PLAYER = 256
UnitFlags.TYPE_PLAYER = 1024
```
1297 decimal, 0x511 hex.