### PR TITLE
Refactor 'categories' to be an enum type

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,14 +1,21 @@
-/**
- * List of supported categories. Order is the order they show up in the GUI.
- */
-const categories: string[]  = [
-    "2v2",
-    "3v3",
-    "Skirmish",
-    "Solo Shuffle",
-    "Mythic+",
-    "Raids",
-    "Battlegrounds"
+enum VideoCategory {
+  TwoVTwo = '2v2',
+  ThreeVThree = '3v3',
+  Skirmish = 'Skirmish',
+  SoloShuffle = 'Solo Shuffle',
+  MythicPlus = 'Mythic+',
+  Raids = 'Raids',
+  Battlegrounds = 'Battlegrounds',
+};
+
+const categories: string[] = [
+  VideoCategory.TwoVTwo,
+  VideoCategory.ThreeVThree,
+  VideoCategory.Skirmish,
+  VideoCategory.SoloShuffle,
+  VideoCategory.MythicPlus,
+  VideoCategory.Raids,
+  VideoCategory.Battlegrounds,
 ];
 
 /**
@@ -280,4 +287,5 @@ export {
     encountersSepulcher,
     instanceDifficulty,
     InstanceDifficultyType,
+    VideoCategory,
 };

--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -1,7 +1,7 @@
 /* eslint import/prefer-default-export: off, import/no-mutable-exports: off */
 import { Combatant } from './combatant';
 import { recorder }  from './main';
-import { battlegrounds }  from './constants';
+import { battlegrounds, VideoCategory }  from './constants';
 
 const tail = require('tail').Tail;
 const glob = require('glob');
@@ -83,7 +83,7 @@ class LogLine {
  */
  type Metadata = {
     name: string;
-    category: string;
+    category: VideoCategory;
     zoneID?: number;
     encounterID?: number;
     difficultyID? : number;
@@ -309,7 +309,7 @@ function handleArenaStartLine (line: LogLine): void {
 
     metadata = {
         name: "name",
-        category: line.args[3],
+        category: (line.args[3] as VideoCategory),
         zoneID: zoneID,
         duration: 0,
         result: false,
@@ -334,7 +334,7 @@ function handleArenaStopLine (line: LogLine): void {
     
     // Helpfully ARENA_MATCH_END events contain the game duration. Solo shuffle
     // ARENA_MATCH_END duration only counts the last game so needs special handling. 
-    if (metadata.category !== "Solo Shuffle") {
+    if (metadata.category !== VideoCategory.SoloShuffle) {
         duration = parseInt(line.args[2], 10);
     } else {
         const soloShuffleStopDate = line.date();
@@ -401,7 +401,7 @@ function handleEncounterStartLine (line: LogLine): void {
 
     metadata = {
         name: "name",
-        category: "Raids",
+        category: VideoCategory.Raids,
         encounterID: encounterID,
         difficultyID: difficultyID,
         duration: 0,
@@ -457,11 +457,11 @@ function handleZoneChange (line: LogLine): void {
     let isRecordingArena = false;
 
     if (metadata !== undefined) {
-        isRecordingBG = (metadata.category === "Battlegrounds");
-        isRecordingArena = (metadata.category === "2v2") || 
-                           (metadata.category === "3v3") || 
-                           (metadata.category === "Solo Shuffle") ||
-                           (metadata.category === "Skirmish");
+        isRecordingBG = (metadata.category === VideoCategory.Battlegrounds);
+        isRecordingArena = (metadata.category === VideoCategory.TwoVTwo) ||
+                           (metadata.category === VideoCategory.ThreeVThree) ||
+                           (metadata.category === VideoCategory.SoloShuffle) ||
+                           (metadata.category === VideoCategory.Skirmish);
     }
 
     if (!isRecording && isNewZoneBG) {
@@ -527,13 +527,12 @@ function handleCombatantInfoLine (line: LogLine): void {
 function battlegroundStart (line: LogLine): void {
     const zoneID = parseInt(line.args[1], 10);
     const battlegroundName = battlegrounds[zoneID];
-    const category = "Battlegrounds";
 
     videoStartDate = line.date();
 
     metadata = {
         name: battlegroundName,
-        category: category,
+        category: VideoCategory.Battlegrounds,
         zoneID: zoneID,
         duration: 0,
         result: false,

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,7 +1,7 @@
 /* eslint import/prefer-default-export: off, import/no-mutable-exports: off */
 import { URL } from 'url';
 import path from 'path';
-import { categories, months, zones, encountersNathria, encountersSanctum, encountersSepulcher }  from './constants';
+import { categories, months, zones, encountersNathria, encountersSanctum, encountersSepulcher, VideoCategory }  from './constants';
 import { Metadata }  from './logutils';
 import ElectronStore from 'electron-store';
 const chalk = require('chalk');
@@ -180,7 +180,7 @@ const getVideoZone = (metadata: Metadata) => {
     const encounterID = metadata.encounterID;
     const category = metadata.category;
 
-    const isRaidEncounter = (category === "Raids") && encounterID; 
+    const isRaidEncounter = (category === VideoCategory.Raids) && encounterID; 
     let zone: string;
     
     if (isRaidEncounter) {

--- a/src/renderer/VideoButton.tsx
+++ b/src/renderer/VideoButton.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Tab from '@mui/material/Tab';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import { categories, videoButtonSx, specToClass }  from '../main/constants';
+import { categories, videoButtonSx, specToClass, VideoCategory }  from '../main/constants';
 import { getResultText, getFormattedDuration, getInstanceDifficulty } from './rendererutils';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Check from '@mui/icons-material/Check';
@@ -21,7 +21,7 @@ export default function VideoButton(props: any) {
   const videoIndex = props.index;
 
   const categoryIndex = state.categoryIndex;
-  const category = categories[categoryIndex]
+  const category = categories[categoryIndex] as VideoCategory
 
   const video = state.videoState[category][videoIndex];
   const videoPath = video.fullPath;
@@ -49,14 +49,14 @@ export default function VideoButton(props: any) {
 
   // BGs don't log COMBATANT_INFO events so we can't display a lot of stuff
   // that we can for other categories. 
-  const isBG = category === "Battlegrounds";
-  const isRaid = category === "Raids";
+  const isBG = category === VideoCategory.Battlegrounds;
+  const isRaid = category === VideoCategory.Raids;
   const videoInstanceDifficulty = isRaid ? getInstanceDifficulty(video.difficultyID) : null;
 
   let buttonImage;
 
   // TODO, clean this ugly code up. What about M+ eventually?
-  if (category === "Raids") {
+  if (isRaid) {
     buttonImage = Images.raid[video.encounterID];
   } else if (isBG) {
     buttonImage = Images.battleground[video.zoneID];

--- a/src/renderer/VideoButton.tsx
+++ b/src/renderer/VideoButton.tsx
@@ -21,7 +21,7 @@ export default function VideoButton(props: any) {
   const videoIndex = props.index;
 
   const categoryIndex = state.categoryIndex;
-  const category = categories[categoryIndex] as VideoCategory
+  const category = categories[categoryIndex] as VideoCategory;
 
   const video = state.videoState[category][videoIndex];
   const videoPath = video.fullPath;

--- a/src/renderer/rendererutils.ts
+++ b/src/renderer/rendererutils.ts
@@ -1,24 +1,20 @@
-import { instanceDifficulty, InstanceDifficultyType } from "main/constants";
+import { instanceDifficulty, InstanceDifficultyType, VideoCategory } from "main/constants";
 
 /**
  * isCategoryPVP
  */
- const isCategoryPVP = (category: string) => {
+ const isCategoryPVP = (category: VideoCategory) => {
     if (!category) return false;
 
     const pvpCategories = [
-        "2v2", 
-        "3v3", 
-        "Skirmish", 
-        "Solo Shuffle", 
-        "Battlegrounds"
+        VideoCategory.TwoVTwo,
+        VideoCategory.ThreeVThree,
+        VideoCategory.Skirmish,
+        VideoCategory.SoloShuffle,
+        VideoCategory.Battlegrounds,
     ];
 
-    if (pvpCategories.includes(category)) {
-        return true;
-    } else {
-        return false;
-    }
+    return pvpCategories.indexOf(category) !== -1;
 }  
 
 const getInstanceDifficulty = (difficultyID: number): InstanceDifficultyType | null => {
@@ -32,11 +28,11 @@ const getInstanceDifficulty = (difficultyID: number): InstanceDifficultyType | n
 /**
  * getResultText
  */
- const getResultText = (category: string, isGoodResult: boolean) => {
+ const getResultText = (category: VideoCategory, isGoodResult: boolean) => {
 
     // Not sure how we can decide who won or lost yet. 
     // Combat log doesn't make it obvious.
-    if ((category == "Battlegrounds") || (category == "Solo Shuffle")) {
+    if (category == VideoCategory.Battlegrounds || category == VideoCategory.SoloShuffle) {
         return "";
     }
 

--- a/src/renderer/rendererutils.ts
+++ b/src/renderer/rendererutils.ts
@@ -14,7 +14,7 @@ import { instanceDifficulty, InstanceDifficultyType, VideoCategory } from "main/
         VideoCategory.Battlegrounds,
     ];
 
-    return pvpCategories.indexOf(category) !== -1;
+    return pvpCategories.includes(category);
 }  
 
 const getInstanceDifficulty = (difficultyID: number): InstanceDifficultyType | null => {


### PR DESCRIPTION
As the title states. A simple refactor to eliminate literal strings from comparisons and assignments.