### PR TITLE
Fix: Wrong/missing import for AppStatus

### DIFF
--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -1,8 +1,9 @@
 import { Metadata } from './logutils';
 import { writeMetadataFile, runSizeMonitor, getNewestVideo, deleteVideo, cutVideo, addColor } from './util';
-import { AppStatus, mainWindow }  from './main';
+import { mainWindow }  from './main';
 import { app } from 'electron';
 import path from 'path';
+import { AppStatus } from './types';
 
 const obsRecorder = require('./obsRecorder');
 const fs = require('fs');


### PR DESCRIPTION
There was a mixup of `AppStatus` being moved from `main/main.ts` to `main/types.ts` and a reference wasn't updated to reflect that.