### PR TITLE
Write metadata with UTF-8 encoding

### DIFF
--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -134,7 +134,13 @@ const getMetadataForVideo = (video: string) => {
     const metadataFileName = getMetadataFileForVideo(videoPath);
     const jsonString = JSON.stringify(metadata, null, 2);
 
-    return await fspromise.writeFile(metadataFileName, jsonString);
+    return await fspromise.writeFile(
+        metadataFileName,
+        jsonString,
+        {
+            encoding: 'utf-8',
+        }
+    );
 }
 
 /**


### PR DESCRIPTION
Ensure that metadata JSON is written to disk in UTF-8 encoding to support e.g. Russian character names. This relates to the new `playerDeath` metadata array which can look garbled when Russian character names appear in it.