### PR TITLE
Make <VideoButton/> for M+ look nice

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -199,13 +199,13 @@ h2 {
   text-align: center;
 }
 
-.dungeon .zone {
-  font-size: 16px;
-  top: 35px;
-}
-
-.dungeon .zone.level {
-  top: 55px;
+.dungeon .encounter {
+  font-size: 18px;
+  display: flex;
+  top: 0;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }
 
 .time {

--- a/src/renderer/VideoButton.tsx
+++ b/src/renderer/VideoButton.tsx
@@ -202,8 +202,12 @@ export default function VideoButton(props: any) {
             }
             { isMythicPlus &&
               <div>
-                <div className='zone'>{ dungeonsByMapId[video.challengeMode.mapId] }</div>
-                <div className='zone level'>+{ video.challengeMode.level }</div>
+                <div className='encounter'>
+                  { dungeonsByMapId[video.challengeMode.mapId] }
+                </div>
+                <div className='instance-difficulty difficulty-mythic'>
+                  +{ video.challengeMode.level }
+                </div>
               </div>
             }
             <div className='time' title={ dateHoverText }>{ dateDisplay }</div>    


### PR DESCRIPTION
- Remove "zone" text and include only the map name, which is the only important part for a dungeon.

- Add Keystone level at the top where raids have their difficulty letter displayed and make it LEGENDARY colored.

- Make dungeon map name centered vertically and horizontally to it looks nice