### PR TITLE
Make video player settings global

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,7 +11,7 @@ import Store from 'electron-store';
 const obsRecorder = require('./obsRecorder');
 import { Recorder } from './recorder';
 import { getAvailableAudioInputDevices, getAvailableAudioOutputDevices } from './obsAudioDeviceUtils';
-import { AppStatus } from './types';
+import { AppStatus, VideoPlayerSettings } from './types';
 import { net } from 'electron';
 let recorder: Recorder;
 
@@ -43,6 +43,12 @@ let monitorIndex: number = getNumberConfigSafe(cfg, 'monitor-index');
 let audioInputDevice: string = getStringConfigSafe(cfg, 'audio-input-device', 'all');
 let audioOutputDevice: string = getStringConfigSafe(cfg, 'audio-output-device', 'all');
 let minEncounterDuration: number = getNumberConfigSafe(cfg, 'min-encounter-duration');
+
+// Default video player settings on app start
+const videoPlayerSettings: VideoPlayerSettings = {
+  muted: false,
+  volume: 1,
+};
 
 if (!monitorIndex) {
   monitorIndex = defaultMonitorIndex(cfg);
@@ -428,6 +434,24 @@ ipcMain.on('getAudioDevices', (event) => {
   event.returnValue = {
     input: getAvailableAudioInputDevices(),
     output: getAvailableAudioOutputDevices(),
+  }
+});
+
+/**
+ * Set/Get global video player settings
+ */
+ipcMain.on('videoPlayerSettings', (event, args) => {
+  switch (args[0]) {
+    case 'get':
+      event.returnValue = videoPlayerSettings;
+      break;
+
+    case 'set':
+      const settings = (args[1] as VideoPlayerSettings);
+
+      videoPlayerSettings.muted = settings.muted;
+      videoPlayerSettings.volume = settings.volume;
+      break;
   }
 });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, IpcRendererEvent } from 'electron';
 
-export type Channels = 'mainWindow' | 'settingsWindow' | 'getVideoState' | 'contextMenu' | 'logPath' | 'openURL' | 'test' | 'getAudioDevices';
+export type Channels = 'mainWindow' | 'settingsWindow' | 'getVideoState' | 'contextMenu' | 'logPath' | 'openURL' | 'test' | 'getAudioDevices' | 'videoPlayerSettings';
 
 contextBridge.exposeInMainWorld('electron', {
   store: {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -54,8 +54,18 @@ type PlayerDeathType = {
   timestamp: number,
 };
 
+/**
+ * Type that describes selected video player settings that we want to keep
+ * across changes in the UI like selecting a new video, new category, etc.
+ */
+type VideoPlayerSettings = {
+    muted: boolean;
+    volume: number;
+};
+
 export {
     AppStatus,
     UnitFlags,
     PlayerDeathType,
+    VideoPlayerSettings,
 }


### PR DESCRIPTION
Closes #99.

When a video is muted or the volume changed, that setting would only persist within the selected video category (e.g. 3v3) and if a different category was selected, the settings would reset which was undesirable.

This has been changed such that the settings are _global_ across the app regardless of category and video selection.

### In types.ts:

- New type `VideoPlayerSettings` which contains the muted/volume state values that we want to preserve.

### In preload.ts:

- New IPC channel `videoPlayerSettings` with two main functions as `args[0]`:

  `get`: retrieve the stored settings
  `set`: store the settings given in `args[1]`

### In main.ts:

- IPC listener to get/set video player settings.

### In Layout.tsx:

- New function `handleVideoPlayerVolumeChange()` which handles saving the state of the muted/volume when it changes and sets the values in the existing state, but doesn't apply it as that will happen in due time whenever a new video or category is selected.
- Formatted the `<video/>` element over multiple lines for readability.