### PR TITLE
Fix crashing with invalid configuration

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -425,10 +425,18 @@ ipcMain.on('getVideoState', (event) => {
 });
 
 ipcMain.on('getAudioDevices', (event) => {
+  // We can only get this information if the recorder (OBS) has been
+  // initialized and that only happens when the storage directory has
+  // been configured.
+  if (!recorder) {
+    event.returnValue = { input: [], output: [] };
+    return;
+  }
+
   event.returnValue = {
     input: getAvailableAudioInputDevices(),
     output: getAvailableAudioOutputDevices(),
-  }
+  };
 });
 
 /**


### PR DESCRIPTION
Fixes issue #119 which describes a problem in which an invalid configuration, as how the initial state of the app is for new users, will crash when one attempts to open the Settings window.

This is due to OBS not yet being initialized but attempted to be used to retrieve available input/output audio devices.

The fix is to simply return an empty array for these device arrays and let the config only show "All" and "None" until OBS has been initialized.