### PR TITLE
Add more logging to size monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/icons-material": "^5.8.4",
         "@mui/lab": "^5.0.0-alpha.80",
         "@mui/material": "^5.6.4",
+        "byte-size": "^8.1.0",
         "electron-debug": "^3.2.0",
         "electron-log": "^4.4.8",
         "electron-osx-prompt": "^1.4.1",
@@ -4685,6 +4686,14 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/byte-size": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.0.tgz",
+      "integrity": "sha512-FkgMTAg44I0JtEaUAvuZTtU2a2YDmBRbQxdsQNSMtLCjhG0hMcF5b1IMN9UjSCJaU4nvlj/GER7B9sI4nKdCgA==",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/bytes": {
@@ -20833,6 +20842,11 @@
         "debug": "^4.3.2",
         "sax": "^1.2.4"
       }
+    },
+    "byte-size": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.0.tgz",
+      "integrity": "sha512-FkgMTAg44I0JtEaUAvuZTtU2a2YDmBRbQxdsQNSMtLCjhG0hMcF5b1IMN9UjSCJaU4nvlj/GER7B9sI4nKdCgA=="
     },
     "bytes": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.80",
     "@mui/material": "^5.6.4",
+    "byte-size": "^8.1.0",
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.8",
     "electron-osx-prompt": "^1.4.1",


### PR DESCRIPTION
Also print out size of maximum and the total video library size using `byte-size` package, that will automatically format it with appropriate unit suffixes and such.

Remove the `Promise.resolve()` from `runSizeMonitor()` as it isn't needed for a return type of `Promise<void>`.

Add `path.resolve()` to normalize all path separators for the OS so logging doesn't have `C:\..\` and `C:/../` which can look confusing.