### PR TITLE
Remember the selected category across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Issue 142](https://github.com/aza547/wow-recorder/issues/142) - Make it possible to stop recording.
 - Now loads videos asynchronously to improve application reponsiveness on start up with many videos
+- Remember the selected category across application restarts
 
 ### Changed
 ### Fixed

--- a/src/renderer/Layout.tsx
+++ b/src/renderer/Layout.tsx
@@ -19,6 +19,7 @@ import { VideoPlayerSettings } from 'main/types';
  * For shorthand referencing.
  */
 const ipc = window.electron.ipcRenderer;
+const store = window.electron.store;
 
 /**
  * Needed to style the tabs with the right color.
@@ -101,6 +102,7 @@ const tabProps = (index: number) => {
  * the app is restarted. 
  */
 const videoPlayerSettings = (ipc.sendSync('videoPlayerSettings', ['get']) as VideoPlayerSettings);
+const selectedCategory = ((store.get('selected-category') ?? 0) as number);
 
 let videoState: { [key: string]: any } = {}
 
@@ -110,7 +112,7 @@ let videoState: { [key: string]: any } = {}
 export default function Layout() {
 
   const [state, setState] = React.useState({
-    categoryIndex: 0,
+    categoryIndex: selectedCategory,
     videoIndex: 0,
     videoState,
     videoMuted: videoPlayerSettings.muted,
@@ -142,6 +144,8 @@ export default function Layout() {
    * Update the state variable following a change of selected category.
    */
   const handleChangeCategory = (_event: React.SyntheticEvent, newValue: number) => {
+    store.set('selected-category', newValue);
+
     setState(prevState => {
       return {
         ...prevState,

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -1,9 +1,10 @@
+import ElectronStore from 'electron-store';
 import { Channels } from 'main/preload';
 
 declare global {
   interface Window {
     electron: {
-      store: any;
+      store: ElectronStore;
       ipcRenderer: {
         sendMessage(channel: Channels, args: unknown[]): void;
         sendSync(channel: Channels, args: unknown[]): any;


### PR DESCRIPTION
Whenever a new category is selected, it'll be saved to the `selected-category` persistent setting and restored when the app restarts.