### PR TITLE
Avoid hot-reloading during development for .git

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "patterns": [
       "!./src/main/osn-data/**",
       "!./osn-data/**",
-      "!./src/main/logs/**"
+      "!./src/main/logs/**",
+      "!./.git/**",
+      "!./resources/**"
     ]
   },
   "lint-staged": {


### PR DESCRIPTION
During development, hot-reloading can create annoying situations when Git modifies files in `.git` as well as when test scripts or files are updated in `resources/`.

These paths have been added to ElectroMon's patterns with a negation to avoid them triggering hot-reloading.