### PR TITLE
Fix UNIT_DIED handling before recording starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Issue 134](https://github.com/aza547/wow-recorder/issues/134) - Only handle UNIT_DIED when a recording activity is in progress
 - [Issue 142](https://github.com/aza547/wow-recorder/issues/142) - Make it possible to stop recording.
 - Now loads videos asynchronously to improve application reponsiveness on start up with many videos
 

--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -732,6 +732,12 @@ const registerPlayerDeath = (timestamp: number, name: string, specId: number): v
  * Handle a unit dying, but only if it's a player.
  */
  function handleUnitDiedLine (line: LogLine): void {
+    // Only handle UNIT_DIED if we have a videoStartDate AND we're recording
+    // We're not interested in player deaths outside of an active activity/recording.
+    if (!videoStartDate || !recorder.isRecording) {
+        return;
+    }
+
     const unitFlags = parseInt(line.args[7], 16);
     const isUnitUnconsciousAtDeath = Boolean(parseInt(line.args[9], 10));
 


### PR DESCRIPTION
In the case of raids, it's not unusual for a player to die _before_ an encounter starts for various reasons (e.g. trash) but as we don't have a `videoStartDate` before the recording/encounter starts, this caused the application to crash due to trying to access `videStartDate.getTime()`.

This fix simply guards `handleUnitDiedLine()` in such a way where if we are not recording or if we don't have a valid `videoStartdate`, we'll ignore `UNIT_DIED`.

Fixes issue #134