### PR TITLE
Name video files more sensibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Issue 52](https://github.com/aza547/wow-recorder/issues/52) - Video files are now named more sensibly according to their category
 - [Issue 142](https://github.com/aza547/wow-recorder/issues/142) - Make it possible to stop recording.
 - Now loads videos asynchronously to improve application reponsiveness on start up with many videos
 

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,3 +1,5 @@
+import { NumberKeyToStringValueMapType, RaidInstanceType } from "./types";
+
 enum VideoCategory {
   TwoVTwo = '2v2',
   ThreeVThree = '3v3',
@@ -39,7 +41,7 @@ const months: string[] = [
 /**
  * Battlegrounds by ID. 
  */
- const battlegrounds: { [id: number]: string; } = {
+ const battlegrounds: NumberKeyToStringValueMapType = {
   30:	  "Alterac Valley",
   2107: "Arathi Basin",
   1681: "Arathi Basin",
@@ -61,7 +63,7 @@ const months: string[] = [
 /**
  * Arenas by ID. 
  */
- const arenas: { [id: number]: string; } = {
+ const arenas: NumberKeyToStringValueMapType = {
   1672: "Blade's Edge",
   617: "Dalaran Sewers",
   1505: "Nagrand Arena",
@@ -81,7 +83,7 @@ const months: string[] = [
 /**
  * Encounters by ID.  
  */
-const encountersSepulcher: { [id: number]: string; } = {
+const encountersSepulcher: NumberKeyToStringValueMapType = {
   2537: "Jailer",
   2512: "Guardian",
   2529: "Halondrus",
@@ -95,7 +97,7 @@ const encountersSepulcher: { [id: number]: string; } = {
   2553: "Xy'mox",
 }
 
-const encountersSanctum: { [id: number]: string; } = {
+const encountersSanctum: NumberKeyToStringValueMapType = {
   2523: "The Tarragrue",
   2433: "Jailer's Eye",
   2429: "The Nine",
@@ -108,7 +110,7 @@ const encountersSanctum: { [id: number]: string; } = {
   2435: "Sylvanas",
 }
 
-const encountersNathria: { [id: number]: string; } = {
+const encountersNathria: NumberKeyToStringValueMapType = {
   2398: "Shriekwing",
   2418: "Huntsman",
   2402: "Sun King",
@@ -121,16 +123,28 @@ const encountersNathria: { [id: number]: string; } = {
   2407: "Denathrius"
 }
 
-const raids: { [id: number]: string; } = {
+const raidEncountersById: NumberKeyToStringValueMapType = {
   ...encountersNathria,
   ...encountersSanctum,
   ...encountersSepulcher
 }
 
 /**
+ * List of raids and their encounters
+ * This is used to figure out the raid name of a given encounter as that
+ * information is not available in `ENCOUNTER_START` and we shouldn't and
+ * can't rely on `ZONE_CHANGE` for this.
+ */
+const raidInstances: RaidInstanceType[] = [
+  { zoneId: 13224, name: 'Castle Nathria', encounters: encountersNathria },
+  { zoneId: 13561, name: 'Sanctum of Domination', encounters: encountersSanctum },
+  { zoneId: 13742, name: 'Sepulcher of the First Ones', encounters: encountersSepulcher },
+];
+
+/**
  * Dungeons by zone ID.
  */
-const dungeonsByZoneId: { [id: number]: string; } = {
+const dungeonsByZoneId: NumberKeyToStringValueMapType = {
   1651: 'Return to Karazhan',
   1208: 'Grimrail Depot',
   1195: 'Iron Docks',
@@ -151,7 +165,7 @@ const dungeonsByZoneId: { [id: number]: string; } = {
  * Names have been shortened, or abbreviated due to size constraints in
  * <VideoButton/>
  */
-const dungeonsByMapId: { [id: number]: string; } = {
+const dungeonsByMapId: NumberKeyToStringValueMapType = {
   166: 'Grimrail Depot',
   169: 'Iron Docks',
   206: 'Neltharion\'s Lair',
@@ -201,7 +215,7 @@ const dungeonTimersByMapId: { [id: number]: number[]; } = {
   166: [(30 * 60), (24 * 60), (18 * 60)],
 }
 
-const dungeonEncounters: { [id: number]: string } = {
+const dungeonEncounters: NumberKeyToStringValueMapType = {
   // Grimrail Depot
   1715: 'Rocketspark and Borka',
   1732: 'Nitrogg Thundertower',
@@ -304,14 +318,13 @@ const dungeonEncounters: { [id: number]: string } = {
   2440: "Myza's Oasis",
 };
 
-const instanceNamesByZoneId: { [id: number]: string } = {
+const instanceNamesByZoneId: NumberKeyToStringValueMapType = {
+  ...battlegrounds,
+  ...arenas,
   ...dungeonsByZoneId,
-  13224: 'Castle Nathria',
-  13561: 'Sanctum of Domination',
-  13742: 'Sepulcher of the First Ones',
 };
 
-const dungeonAffixesById: { [id: number]: string } = {
+const dungeonAffixesById: NumberKeyToStringValueMapType = {
     1: 'Overflowing',
     2: 'Skittish',
     3: 'Volcanic',
@@ -343,12 +356,17 @@ const dungeonAffixesById: { [id: number]: string } = {
 /**
  * Zones by ID. 
  */
-const zones: { [id: number]: string; } = {
+const zones: NumberKeyToStringValueMapType = {
     ...arenas,
-    ...raids,
+    ...raidEncountersById,
     ...battlegrounds,
     ...dungeonsByZoneId,
 }
+
+const instanceEncountersById: NumberKeyToStringValueMapType = {
+  ...raidEncountersById,
+  ...dungeonEncounters,
+};
 
 type InstanceDifficultyPartyType = 'party' | 'raid' | 'pvp'
 type ImstanceDifficultyIdType = 'lfr' | 'normal' | 'heroic' | 'mythic' | 'pvp'
@@ -488,7 +506,7 @@ export {
     videoButtonSx,
     zones,
     arenas,
-    raids,
+    raidEncountersById,
     battlegrounds,
     dungeonsByMapId,
     dungeonsByZoneId,
@@ -501,6 +519,8 @@ export {
     encountersNathria,
     encountersSepulcher,
     instanceDifficulty,
+    instanceEncountersById,
     InstanceDifficultyType,
     VideoCategory,
+    raidInstances,
 };

--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -1,0 +1,116 @@
+import { dungeonsByMapId, instanceDifficulty, InstanceDifficultyType, instanceEncountersById, instanceNamesByZoneId, raidInstances, VideoCategory, zones } from "./constants";
+import { Metadata } from "./logutils";
+import { RaidInstanceType } from "./types";
+
+/**
+ * Get a result text appropriate for the video category that signifies a
+ * win or a loss, of some sort.
+ */
+export const getVideoResultText = (category: VideoCategory, isGoodResult: boolean): string => {
+
+    // Not sure how we can decide who won or lost yet.
+    // Combat log doesn't make it obvious.
+    if (category == VideoCategory.Battlegrounds || category == VideoCategory.SoloShuffle) {
+        return "";
+    }
+
+    switch (category) {
+        case VideoCategory.MythicPlus:
+            return isGoodResult ? "Time" : "Depl";
+
+        case VideoCategory.Raids:
+            return isGoodResult ? "Kill" : "Wipe";
+
+        default:
+            return isGoodResult ? "Win" : "Loss";
+    }
+};
+
+/**
+ * Get the name of a dungeon by its map ID
+ */
+export const getDungeonByMapId = (mapId?: number): string => {
+    if (mapId && dungeonsByMapId.hasOwnProperty(mapId)) {
+        return dungeonsByMapId[mapId];
+    }
+
+    return 'Unknown Dungeon';
+};
+
+/**
+ * Get the name of a boss encounter based on its encounter ID
+ */
+export const getEncounterNameById = (encounterId? : number): string => {
+    if (encounterId && instanceEncountersById.hasOwnProperty(encounterId)) {
+        return instanceEncountersById[encounterId];
+    }
+
+    return 'Unknown Boss';
+};
+
+/**
+ * Get the name of a zone in WoW based on its zone ID
+ */
+export const getInstanceNameByZoneId = (zoneId?: number): string => {
+    if (zoneId && instanceNamesByZoneId.hasOwnProperty(zoneId)) {
+        return instanceNamesByZoneId[zoneId];
+    }
+
+    return 'Unknown Zone';
+};
+
+/**
+ * Get the difficulty of an instance based on its difficulty ID, as found in
+ * `ENCOUNTER_START` log lines.
+ */
+export const getInstanceDifficulty = (difficultyId: number): InstanceDifficultyType | null => {
+    if (instanceDifficulty.hasOwnProperty(difficultyId)) {
+        return instanceDifficulty[difficultyId];
+    }
+
+    return null;
+};
+
+/**
+ * Get the zone name.
+ */
+export const getVideoZone = (metadata: Metadata) => {
+    const zoneID = metadata.zoneID;
+    const encounterID = metadata.encounterID;
+
+    switch (metadata.category) {
+        case VideoCategory.MythicPlus:
+            return getInstanceNameByZoneId(zoneID);
+
+        case VideoCategory.Raids:
+            return getRaidNameByEncounterId(encounterID);
+
+        default:
+            if (zoneID && zones.hasOwnProperty(zoneID)) {
+                return zones[zoneID];
+            }
+    }
+
+    return "Unknown Zone";
+}
+
+/**
+ * Get the raid name from the encounter ID.
+ */
+export const getRaidNameByEncounterId = (encounterID?: number) => {
+    const raid = getRaidByEncounterId(encounterID);
+    if (!raid) {
+        return 'Unknown Raid';
+    }
+
+    return raid.name;
+}
+
+/**
+ * Get the raid instance from an encounter ID.
+ */
+export const getRaidByEncounterId = (zoneID?: number): RaidInstanceType | undefined => {
+    const raid = raidInstances.filter(r => zoneID && r.encounters.hasOwnProperty(zoneID))
+
+    return raid.pop();
+};

--- a/src/main/helpers.ts
+++ b/src/main/helpers.ts
@@ -1,3 +1,11 @@
+/**
+ * Please keep this file FREE from any filesystem related code as it
+ * is used in both the backend and the frontend, and the frontend does
+ * not have access to import 'fs', for example.
+ *
+ * It is okay to import things from other modules that import 'fs' as
+ * long as you don't import a function that uses the 'fs' module.
+ */
 import { dungeonsByMapId, instanceDifficulty, InstanceDifficultyType, instanceEncountersById, instanceNamesByZoneId, raidInstances, VideoCategory, zones } from "./constants";
 import { Metadata } from "./logutils";
 import { RaidInstanceType } from "./types";
@@ -8,8 +16,7 @@ import { RaidInstanceType } from "./types";
  */
 export const getVideoResultText = (category: VideoCategory, isGoodResult: boolean): string => {
 
-    // Not sure how we can decide who won or lost yet.
-    // Combat log doesn't make it obvious.
+    // Non-trivial to determine who won a BG/SoloShuffle so just don't report it.
     if (category == VideoCategory.Battlegrounds || category == VideoCategory.SoloShuffle) {
         return "";
     }

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -2,9 +2,12 @@ import { Metadata } from './logutils';
 import { writeMetadataFile, runSizeMonitor, getNewestVideo, deleteVideo, cutVideo, addColor, getSortedVideos } from './util';
 import { mainWindow }  from './main';
 import { AppStatus } from './types';
+import { getDungeonByMapId, getEncounterNameById, getVideoResultText, getInstanceNameByZoneId, getRaidNameByEncounterId } from './helpers';
+import { VideoCategory } from './constants';
+import fs from 'fs';
+import { ChallengeModeDungeon } from './keystone';
 
 const obsRecorder = require('./obsRecorder');
-import fs from 'fs';
 
 type RecorderOptionsType = {
     storageDir: string;
@@ -170,6 +173,7 @@ type RecorderOptionsType = {
      * @param {number} overrun how long to continue recording after stop is called
      */
     stop = (metadata: Metadata, overrun: number = 0) => {
+        const outputFilename = this.getFinalVideoFilename(metadata);
         console.log(addColor("[Recorder] Stop recording after overrun", "green"));
         console.info("[Recorder] Overrun:", overrun);
         console.info("[Recorder]" , JSON.stringify(metadata, null, 2));
@@ -179,7 +183,7 @@ type RecorderOptionsType = {
         setTimeout(async () => {           
             // Take the actions to stop the recording.
             if (!this._isRecording) return;
-            await obsRecorder.stop();       
+            await obsRecorder.stop();
             this._isRecording = false;
             this._isRecordingBuffer = false;
 
@@ -191,7 +195,7 @@ type RecorderOptionsType = {
             if (!isRaid || isLongEnough) {
                 // Cut the video to length and write its metadata JSON file.
                 // Await for this to finish before we return to waiting state.
-                await this.finalizeVideo(metadata);
+                await this.finalizeVideo(metadata, outputFilename);
             }
 
             // Run the size monitor to ensure we stay within size limit.
@@ -219,17 +223,22 @@ type RecorderOptionsType = {
      * 
      * @param {Metadata} metadata the details of the recording
      */
-    finalizeVideo = async (metadata: Metadata) => {
+    finalizeVideo = async (metadata: Metadata, outputFilename?: string): Promise<string> => {
 
         // Gnarly syntax to await for the setTimeout to finish.
-        await new Promise<void> ((resolve) => {
+        return new Promise<string> ((resolve) => {
 
             // It's a bit hacky that we async wait for 2 seconds for OBS to 
             // finish up with the video file. Maybe this can be done better. 
             setTimeout(async () => {
                 const bufferedVideo = await getNewestVideo(this._options.bufferStorageDir);
-                const videoPath = await cutVideo(bufferedVideo, this._options.storageDir, metadata.duration);
-                writeMetadataFile(videoPath, metadata).then(resolve);
+                const videoPath = await cutVideo(bufferedVideo, this._options.storageDir, outputFilename, metadata.duration);
+
+                await writeMetadataFile(videoPath, metadata);
+
+                console.log('[Recorder] Finalized video', videoPath);
+
+                resolve(videoPath);
             }, 
             2000)
         });   
@@ -285,6 +294,52 @@ type RecorderOptionsType = {
 
         obsRecorder.reconfigure(this._options);
         if (mainWindow) mainWindow.webContents.send('refreshState');
+    }
+
+    /**
+     * Generate a filename for the final video of a recording according
+     * to its category, if possible.
+     *
+     * The final filename should contain adequate information to quickly be able
+     * to identify the video files on the filesystem and be able to tell what it
+     * was about and the result of it.
+     */
+    getFinalVideoFilename (metadata: Metadata): string | undefined {
+        let outputFilename = '';
+        let zoneName: string;
+        const resultText = getVideoResultText(metadata.category, metadata.result);
+
+        switch (metadata.category) {
+            case VideoCategory.TwoVTwo:
+            case VideoCategory.ThreeVThree:
+            case VideoCategory.Skirmish:
+            case VideoCategory.SoloShuffle:
+                zoneName = getInstanceNameByZoneId(metadata.zoneID);
+                outputFilename = `${zoneName} (${resultText})`;
+            break;
+
+            case VideoCategory.Raids:
+                const encounterName = getEncounterNameById(metadata.encounterID);
+                zoneName = getRaidNameByEncounterId(metadata.encounterID);
+                outputFilename = `${zoneName}, ${encounterName} (${resultText})`;
+            break;
+
+            case VideoCategory.MythicPlus:
+                if (metadata.challengeMode) {
+                    const cm = metadata.challengeMode;
+                    const keystoneUpgradeLevel = ChallengeModeDungeon.calculateKeystoneUpgradeLevel(cm.allottedTime, cm.duration);;
+                    const resultText = cm?.timed ? '+' + keystoneUpgradeLevel : 'Depleted';
+
+                    outputFilename = `${getDungeonByMapId(cm.mapId)} +${cm.level} (${resultText})`;
+                }
+            break;
+        }
+
+        if (!outputFilename) {
+            return;
+        }
+
+        return `{${metadata.category}} ${outputFilename}`;
     }
 }
 

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -300,32 +300,22 @@ type RecorderOptionsType = {
      */
     getFinalVideoFilename (metadata: Metadata): string | undefined {
         let outputFilename = '';
-        let zoneName: string;
         const resultText = getVideoResultText(metadata.category, metadata.result);
 
         switch (metadata.category) {
-            case VideoCategory.TwoVTwo:
-            case VideoCategory.ThreeVThree:
-            case VideoCategory.Skirmish:
-            case VideoCategory.SoloShuffle:
-                zoneName = getInstanceNameByZoneId(metadata.zoneID);
-                outputFilename = `${zoneName} (${resultText})`;
-            break;
-
             case VideoCategory.Raids:
                 const encounterName = getEncounterNameById(metadata.encounterID);
-                zoneName = getRaidNameByEncounterId(metadata.encounterID);
-                outputFilename = `${zoneName}, ${encounterName} (${resultText})`;
+                const raidName = getRaidNameByEncounterId(metadata.encounterID);
+                outputFilename = `${raidName}, ${encounterName} (${resultText})`;
             break;
 
             case VideoCategory.MythicPlus:
-                if (metadata.challengeMode) {
-                    const cm = metadata.challengeMode;
-                    const keystoneUpgradeLevel = ChallengeModeDungeon.calculateKeystoneUpgradeLevel(cm.allottedTime, cm.duration);;
-                    const resultText = cm?.timed ? '+' + keystoneUpgradeLevel : 'Depleted';
+                outputFilename = this.getFinalVideoFilenameForCM(metadata.challengeMode);
+            break;
 
-                    outputFilename = `${getDungeonByMapId(cm.mapId)} +${cm.level} (${resultText})`;
-                }
+            default:
+                const zoneName = getInstanceNameByZoneId(metadata.zoneID);
+                outputFilename = `${zoneName} (${resultText})`;
             break;
         }
 
@@ -333,7 +323,22 @@ type RecorderOptionsType = {
             return;
         }
 
-        return `{${metadata.category}} ${outputFilename}`;
+        return metadata.category + ' ' + outputFilename;
+    }
+
+    /**
+     * Construct a video filename for a Mythic Keystone dungeon with information
+     * about level, keystone upgrade levels and what have we.
+     */
+    getFinalVideoFilenameForCM(cm?: ChallengeModeDungeon): string {
+        if (!cm) {
+            return '';
+        }
+
+        const keystoneUpgradeLevel = ChallengeModeDungeon.calculateKeystoneUpgradeLevel(cm.allottedTime, cm.duration);;
+        const resultText = cm?.timed ? '+' + keystoneUpgradeLevel : 'Depleted';
+
+        return `${getDungeonByMapId(cm.mapId)} +${cm.level} (${resultText})`;
     }
 }
 

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -315,7 +315,10 @@ type RecorderOptionsType = {
 
             default:
                 const zoneName = getInstanceNameByZoneId(metadata.zoneID);
-                outputFilename = `${zoneName} (${resultText})`;
+                outputFilename = zoneName;
+                if (resultText) {
+                    outputFilename += ' (' + resultText + ')'
+                }
             break;
         }
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -68,10 +68,22 @@ enum FileSortDirection {
     OldestFirst,
 };
 
+type NumberKeyToStringValueMapType = {
+    [id: number]: string;
+};
+
+type RaidInstanceType = {
+    zoneId: number;
+    name: string;
+    encounters: NumberKeyToStringValueMapType,
+};
+
 export {
     AppStatus,
     UnitFlags,
     PlayerDeathType,
     VideoPlayerSettings,
     FileSortDirection,
+    NumberKeyToStringValueMapType,
+    RaidInstanceType,
 }

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -429,7 +429,8 @@ const cutVideo = async (
     ): Promise<string> => {
     
     const videoFileName = path.basename(initialFile, '.mp4');
-    const baseVideoFilename = sanitizeFilename(videoFileName + (outputFilename ? ' - ' + outputFilename : ''));
+    const videoFilenameSuffix = outputFilename ? ' - ' + outputFilename : '';
+    const baseVideoFilename = sanitizeFilename(videoFileName + videoFilenameSuffix);
     const finalVideoPath = path.join(finalDir, baseVideoFilename + ".mp4");
 
     return new Promise<string> ((resolve) => {

--- a/src/renderer/VideoButton.tsx
+++ b/src/renderer/VideoButton.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { Tab, Menu, MenuItem, Divider } from '@mui/material';
 import { VideoCategory, categories, videoButtonSx, specializationById, dungeonsByMapId, dungeonTimersByMapId }  from 'main/constants';
 import { TimelineSegmentType, ChallengeModeDungeon } from 'main/keystone';
-import { getResultText, getFormattedDuration, getVideoResult, getInstanceDifficulty, getDungeonEncounterById } from './rendererutils';
+import { getFormattedDuration, getVideoResult } from './rendererutils';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Check from '@mui/icons-material/Check';
 import * as Images from './images'
+import { getEncounterNameById, getInstanceDifficulty, getVideoResultText } from 'main/helpers';
 
 /**
  * For shorthand referencing. 
@@ -25,7 +26,7 @@ export default function VideoButton(props: any) {
   const isGoodResult = getVideoResult(video);
   // Need to not be const as it will be modified later if the video is of a
   // Mythic Keystone dungeon.
-  let resultText = getResultText(category, isGoodResult);
+  let resultText = getVideoResultText(category, isGoodResult);
   const MMR = video.teamMMR ? ("MMR: " + video.teamMMR) : undefined;
 
   const isProtected = video.protected;
@@ -144,10 +145,10 @@ export default function VideoButton(props: any) {
       if (segment.segmentType == TimelineSegmentType.BossEncounter) {
         timelineSegmentMenu = <div className='segment-entry'>
           <div className='segment-type segment-type-boss'>
-            <span>{ segmentDurationText }</span>: Boss: { getDungeonEncounterById(segment.encounterId) }
+            <span>{ segmentDurationText }</span>: Boss: { getEncounterNameById(segment.encounterId) }
           </div>
           <div className={ 'segment-result ' + (result ? 'goodResult' : 'badResult') }>
-            { getResultText(VideoCategory.Raids, result) }
+            { getVideoResultText(VideoCategory.Raids, result) }
           </div>
         </div>
       }

--- a/src/renderer/rendererutils.ts
+++ b/src/renderer/rendererutils.ts
@@ -1,36 +1,3 @@
-import { dungeonEncounters, instanceDifficulty, InstanceDifficultyType, VideoCategory } from "main/constants";
-
-const getInstanceDifficulty = (difficultyID: number): InstanceDifficultyType | null => {
-    if (instanceDifficulty.hasOwnProperty(difficultyID)) {
-        return instanceDifficulty[difficultyID];
-    }
-
-    return null;
-}
-
-/**
- * getResultText
- */
- const getResultText = (category: VideoCategory, isGoodResult: boolean) => {
-
-    // Not sure how we can decide who won or lost yet. 
-    // Combat log doesn't make it obvious.
-    if (category == VideoCategory.Battlegrounds || category == VideoCategory.SoloShuffle) {
-        return "";
-    }
-
-    switch (category) {
-        case VideoCategory.MythicPlus:
-            return isGoodResult ? "Time" : "Depl";
-
-        case VideoCategory.Raids:
-            return isGoodResult ? "Kill" : "Wipe";
-
-        default:
-            return isGoodResult ? "Win" : "Loss";
-    }
-} 
-
 const getVideoResult = (video: any): boolean => {
     if (video.challengeMode !== undefined) {
         return Boolean(video.challengeMode.timed)
@@ -51,21 +18,7 @@ const getVideoResult = (video: any): boolean => {
     return formattedDuration;
 }  
 
-/**
- * Return the name of a dungeon encounter (boss) by its encounter ID
- */
- const getDungeonEncounterById = (id: number): string => {
-    if (dungeonEncounters.hasOwnProperty(id)) {
-      return dungeonEncounters[id]
-    }
-
-    return 'Unknown boss';
-}
-
 export {
-    getResultText,
     getFormattedDuration,
-    getInstanceDifficulty,
     getVideoResult,
-    getDungeonEncounterById,
 };


### PR DESCRIPTION
This adds an easy and scalable way to find a raid name from an encounter ID; `raidInstances` is an array of raids with zone ID, name, and a list of encounters (by encounter ID).

Hashmap `instanceEncountersById` has been added to have a single point of truth regarding encounter IDs to encounter name for all instances that support this (dungeons, raids).

A new file has been added, `helpers.ts`, which should be kept FREE from any filesystem related modules (as these cannot be imported in the renderer process) and some of the helper functions from both `utils.ts` as well as `renderutils.ts` has been moved here, as they were needed in multiple places.

This file utilizes the format of `export const methodName = () => {};` as it avoids having a long list of exported names at the bottom, and makes it easy to identify which methods are exported and which aren't.

Furthermore, it vastly improves renaming symbols across the entire codebase because it isn't just changed to `export { newName as oldName }`.

The `Recorder` class will now generate a suitable filename for the final video file based on the given metadata to name the final video files a bit more sensibly.

The format that was chosen results in file names like:

  - `2022-09-22 15-36-33 - {2v2} Enigma Crucible (Win)`
  - `2022-09-22 16-15-54 - {Raids} Sepulcher of the First Ones, Lihuvim (Wipe)`
  - `2022-09-22 15-44-19 - {Mythic+} Mechagon Junkyard +18 (+1)`

So, basically: `{timestamp} - {category} {Zone/Instance}` + some category specific information as seen above, whenever possible.

Replaced all occurances of `{ [id: number]: string; }` with `NumberKeyToStringValueMapType` in `constants.ts`.

Closes #52 