### PR TITLE
Feature: Better monitor selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Issue 81](https://github.com/aza547/wow-recorder/issues/81) - Do something better in UI for monitor selection
 - [Issue 134](https://github.com/aza547/wow-recorder/issues/134) - Only handle UNIT_DIED when a recording activity is in progress
 - [Issue 142](https://github.com/aza547/wow-recorder/issues/142) - Make it possible to stop recording.
 - Now loads videos asynchronously to improve application reponsiveness on start up with many videos

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -258,7 +258,7 @@ const createSettingsWindow = async () => {
 
   settingsWindow = new BrowserWindow({
     show: false,
-    width: 600,
+    width: 770,
     height: 500,
     resizable: (process.env.NODE_ENV === 'production') ? false : true,
     icon: getAssetPath('./icon/settings-icon.svg'),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,7 +5,7 @@
  */
 import path from 'path';
 import { app, BrowserWindow, shell, ipcMain, dialog, Tray, Menu, net, screen, Display } from 'electron';
-import { resolveHtmlPath, loadAllVideos, isConfigReady, deleteVideo, openSystemExplorer, toggleVideoProtected, fixPathWhenPackaged, getPathConfigSafe, getNumberConfigSafe, defaultMonitorIndex, defaultMinEncounterDuration, getStringConfigSafe, defaultAudioDevice } from './util';
+import { resolveHtmlPath, loadAllVideos, isConfigReady, deleteVideo, openSystemExplorer, toggleVideoProtected, fixPathWhenPackaged, getPathConfigSafe, getNumberConfigSafe, defaultMonitorIndex, defaultMinEncounterDuration, getStringConfigSafe, defaultAudioDevice, getAvailableDisplays } from './util';
 import { watchLogs, pollWowProcess, runRecordingTest, forceStopRecording } from './logutils';
 import Store from 'electron-store';
 const obsRecorder = require('./obsRecorder');
@@ -418,26 +418,7 @@ ipcMain.on('settingsWindow', (event, args) => {
   }
 
   if (args[0] === 'getAllDisplays') {
-    const primaryDisplay = screen.getPrimaryDisplay();
-    const returnedDisplays: OurDisplayType[] = [];
-
-    // Iterate over all available displays and make our own list with the
-    // relevant attributes and some extra stuff to make it easier for the
-    // frontend.
-    screen.getAllDisplays().forEach((monitor: Display, index: number) => {
-      const isPrimary = monitor.id === primaryDisplay.id;
-      returnedDisplays.push({
-        id: monitor.id,
-        index,
-        primary: isPrimary,
-        displayFrequency: monitor.displayFrequency,
-        depthPerComponent: monitor.depthPerComponent,
-        size: monitor.size,
-      });
-    });
-
-    event.returnValue = returnedDisplays;
-
+    event.returnValue = getAvailableDisplays();
     return;
   }
 })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,7 +11,7 @@ import Store from 'electron-store';
 const obsRecorder = require('./obsRecorder');
 import { Recorder, RecorderOptionsType } from './recorder';
 import { getAvailableAudioInputDevices, getAvailableAudioOutputDevices } from './obsAudioDeviceUtils';
-import { AppStatus, OurDisplayType, VideoPlayerSettings } from './types';
+import { AppStatus, VideoPlayerSettings } from './types';
 import ElectronStore from 'electron-store';
 let recorder: Recorder;
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,15 +4,14 @@
  * Application entrypoint point.
  */
 import path from 'path';
-import { app, BrowserWindow, shell, ipcMain, dialog, Tray, Menu } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, dialog, Tray, Menu, net, screen, Display } from 'electron';
 import { resolveHtmlPath, loadAllVideos, isConfigReady, deleteVideo, openSystemExplorer, toggleVideoProtected, fixPathWhenPackaged, getPathConfigSafe, getNumberConfigSafe, defaultMonitorIndex, defaultMinEncounterDuration, getStringConfigSafe, defaultAudioDevice } from './util';
 import { watchLogs, pollWowProcess, runRecordingTest, forceStopRecording } from './logutils';
 import Store from 'electron-store';
 const obsRecorder = require('./obsRecorder');
 import { Recorder, RecorderOptionsType } from './recorder';
 import { getAvailableAudioInputDevices, getAvailableAudioOutputDevices } from './obsAudioDeviceUtils';
-import { AppStatus, VideoPlayerSettings } from './types';
-import { net } from 'electron';
+import { AppStatus, OurDisplayType, VideoPlayerSettings } from './types';
 import ElectronStore from 'electron-store';
 let recorder: Recorder;
 
@@ -413,7 +412,34 @@ ipcMain.on('settingsWindow', (event, args) => {
     settingsWindow.close();
   }
 
-  if (args[0] === "openPathDialog") openPathDialog(event, args);
+  if (args[0] === "openPathDialog") {
+      openPathDialog(event, args);
+      return;
+  }
+
+  if (args[0] === 'getAllDisplays') {
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const returnedDisplays: OurDisplayType[] = [];
+
+    // Iterate over all available displays and make our own list with the
+    // relevant attributes and some extra stuff to make it easier for the
+    // frontend.
+    screen.getAllDisplays().forEach((monitor: Display, index: number) => {
+      const isPrimary = monitor.id === primaryDisplay.id;
+      returnedDisplays.push({
+        id: monitor.id,
+        index,
+        primary: isPrimary,
+        displayFrequency: monitor.displayFrequency,
+        depthPerComponent: monitor.depthPerComponent,
+        size: monitor.size,
+      });
+    });
+
+    event.returnValue = returnedDisplays;
+
+    return;
+  }
 })
 
 /**

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,3 +1,5 @@
+import { Rectangle, Size } from "electron";
+
 /**
  * Application status
  */
@@ -75,13 +77,12 @@ enum FileSortDirection {
 type OurDisplayType = {
     id: number,
     index: number,
+    physicalPosition: string,
     primary: boolean,
     displayFrequency: number,
     depthPerComponent: number,
-    size: {
-        width: number,
-        height: number
-    },
+    size: Size,
+    bounds: Rectangle,
   };
 
 export {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,5 +1,3 @@
-import { Rectangle, Size } from "electron";
-
 /**
  * Application status
  */

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -82,8 +82,10 @@ type OurDisplayType = {
     displayFrequency: number,
     depthPerComponent: number,
     size: Size,
-    bounds: Rectangle,
-  };
+    physicalSize: Size,
+    aspectRatio: number,
+    scaleFactor: number,
+};
 
 export {
     AppStatus,

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -68,10 +68,27 @@ enum FileSortDirection {
     OldestFirst,
 };
 
+/**
+ * Specifies the format that we use in Settings to display monitors
+ * to the user.
+ */
+type OurDisplayType = {
+    id: number,
+    index: number,
+    primary: boolean,
+    displayFrequency: number,
+    depthPerComponent: number,
+    size: {
+        width: number,
+        height: number
+    },
+  };
+
 export {
     AppStatus,
     UnitFlags,
     PlayerDeathType,
     VideoPlayerSettings,
     FileSortDirection,
+    OurDisplayType,
 }

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -639,7 +639,7 @@ const getAvailableDisplays = (): OurDisplayType[] => {
     // Iterate over all available displays and make our own list with the
     // relevant attributes and some extra stuff to make it easier for the
     // frontend.
-    const returnedDisplays: OurDisplayType[] = [];
+    const ourDisplays: OurDisplayType[] = [];
     const numberOfMonitors = allDisplays.length;
 
     allDisplays
@@ -647,8 +647,10 @@ const getAvailableDisplays = (): OurDisplayType[] => {
         .forEach((display: Display, index: number) => {
             const isPrimary = display.id === primaryDisplay.id;
             const displayIndex = displayIdToIndex[display.id];
+            const { width, height } = display.size;
+            console.log(display)
 
-            returnedDisplays.push({
+            ourDisplays.push({
                 id: display.id,
                 index: displayIndex,
                 physicalPosition: getDisplayPhysicalPosition(numberOfMonitors, index),
@@ -656,11 +658,16 @@ const getAvailableDisplays = (): OurDisplayType[] => {
                 displayFrequency: display.displayFrequency,
                 depthPerComponent: display.depthPerComponent,
                 size: display.size,
-                bounds: display.bounds,
+                scaleFactor: display.scaleFactor,
+                aspectRatio: width / height,
+                physicalSize: {
+                    width: Math.floor(width * display.scaleFactor),
+                    height: Math.floor(height * display.scaleFactor),
+                }
             });
         });
 
-    return returnedDisplays;
+    return ourDisplays;
 }
 
 export {

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -68,7 +68,9 @@ export default function Settings() {
       value = element.getAttribute("value");
     }
 
-    if (value) window.electron.store.set(setting, value);
+    if (value !== null) {
+      window.electron.store.set(setting, value);
+    }
   }
   
   /**

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -157,8 +157,8 @@ export default function Settings() {
                   <label> Monitor to Record </label>
                   <select id="monitor-index" className="form-control" value={state.monitorIndex} onChange={(event) => setSetting('monitorIndex', event.target.value)}>
                     { displayConfiguration.map((display: OurDisplayType) =>
-                        <option key={ 'display-' + display.id } value={ display.index }>
-                          [{ display.index }] { display.size.width }x{ display.size.height } @ { display.displayFrequency } Hz ({display.physicalPosition}) {display.primary ? ' (Primary)' : ''}
+                        <option key={ 'display-' + display.id } value={ display.index + 1 }>
+                          [{ display.index + 1 }] { display.size.width }x{ display.size.height } @ { display.displayFrequency } Hz ({display.physicalPosition}) {display.primary ? ' (Primary)' : ''}
                         </option>
                     )}
                   </select>

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -37,7 +37,8 @@ export default function Settings() {
   };
   type StateToSettingKeyMapKey = keyof typeof stateKeyToSettingKeyMap;
 
-  const monitorConfiguration = ipc.sendSync('settingsWindow', ['getAllDisplays']);
+  const displayConfiguration = ipc.sendSync('settingsWindow', ['getAllDisplays']);
+
   /**
    * Close window.
    */
@@ -155,9 +156,9 @@ export default function Settings() {
                 <div className="form-group">
                   <label> Monitor to Record </label>
                   <select id="monitor-index" className="form-control" value={state.monitorIndex} onChange={(event) => setSetting('monitorIndex', event.target.value)}>
-                    { monitorConfiguration.map((monitor: OurDisplayType) =>
-                        <option key={ 'display-' + monitor.id } value={ monitor.index }>
-                          [{ monitor.index }] { monitor.size.width }x{ monitor.size.height } @ { monitor.displayFrequency } Hz {monitor.primary ? ' (Primary)' : ''}
+                    { displayConfiguration.map((display: OurDisplayType) =>
+                        <option key={ 'display-' + display.id } value={ display.index }>
+                          [{ display.index }] { display.size.width }x{ display.size.height } @ { display.displayFrequency } Hz ({display.physicalPosition}) {display.primary ? ' (Primary)' : ''}
                         </option>
                     )}
                   </select>

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import ToggleButton from '@mui/material/ToggleButton';
 import { ObsAudioDevice } from 'main/obsAudioDeviceUtils';
+import { OurDisplayType } from 'main/types';
 
 const ipc = window.electron.ipcRenderer;
 
@@ -36,6 +37,7 @@ export default function Settings() {
   };
   type StateToSettingKeyMapKey = keyof typeof stateKeyToSettingKeyMap;
 
+  const monitorConfiguration = ipc.sendSync('settingsWindow', ['getAllDisplays']);
   /**
    * Close window.
    */
@@ -151,8 +153,14 @@ export default function Settings() {
               </div>
               <div className="col-xl-6 col-lg-6 col-md-6 col-sm-6 col-12">
                 <div className="form-group">
-                  <label> Monitor Number </label>
-                  <input type="text" id="monitor-index" className="form-control" placeholder={state.monitorIndex} onChange={(event) => setSetting('monitorIndex', event.target.value)}/>
+                  <label> Monitor to Record </label>
+                  <select id="monitor-index" className="form-control" value={state.monitorIndex} onChange={(event) => setSetting('monitorIndex', event.target.value)}>
+                    { monitorConfiguration.map((monitor: OurDisplayType) =>
+                        <option key={ 'display-' + monitor.id } value={ monitor.index }>
+                          [{ monitor.index }] { monitor.size.width }x{ monitor.size.height } @ { monitor.displayFrequency } Hz {monitor.primary ? ' (Primary)' : ''}
+                        </option>
+                    )}
+                  </select>
                 </div>
               </div>
               <div className="col-xl-6 col-lg-6 col-md-6 col-sm-6 col-12">


### PR DESCRIPTION
### Ensure we save all settings correctly

`getAttribute()` returns `null`, specifically, when an element does not have the given attribute but the logic wasa simply testing the `value` as being 'truthy', which meant that `0` or even an empty string wouldn't be saved.

Monitor indexes are zero based and therefore we couldn't save monitor index `0`. We can now!

### Add methods for providing better monitor selection

Created a new method for retrieving the available monitors from Electron (which is the same as being provided from OBS, but with types!) and creates a new array for the frontend to display to make the selection easier.

### Add frontend selector for monitors

Replace the input text field with a dropdown selector box that displays the available monitors in a slightly better way which should hopefully make it easier to distinguish the individual monitors of ones system.

Example:

![image](https://user-images.githubusercontent.com/875107/191966616-be2d0279-6928-4be2-95fb-98ef5ec3d3d1.png)

Closes #81