### PR TITLE
Remove pointless code

### DIFF
--- a/src/main/obsRecorder.ts
+++ b/src/main/obsRecorder.ts
@@ -188,15 +188,10 @@ const setupScene = (monitorIndex: number) => {
   videoSource.update(settings);
   videoSource.save();
 
-  const outputWidth = physicalWidth;
-  const outputHeight = physicalHeight;
-
-  const videoScaleFactor = physicalWidth / outputWidth;
-
   // A scene is necessary here to properly scale captured screen size to output video size
   const scene = osn.SceneFactory.create('test-scene');
   const sceneItem = scene.add(videoSource);
-  sceneItem.scale = { x: 1.0/ videoScaleFactor, y: 1.0 / videoScaleFactor };
+  sceneItem.scale = { x: 1.0, y: 1.0 };
 
   return scene;
 }


### PR DESCRIPTION
Given the following:

```js
const physicalWidth = 2560;
const physicalHeight = 1440;
```
And the following code:
```js
const outputWidth = physicalWidth;
const outputHeight = physicalHeight;

const videoScaleFactor = physicalWidth / outputWidth;
sceneItem.scale = { x: 1.0 / videoScaleFactor, y: 1.0 / videoScaleFactor };
```
Let's replace the values of these variables and resolve the calculations:
```js
const outputWidth = 2560;
const outputHeight = 1440;

const videoScaleFactor = 2560 / 2560;
sceneItem.scale = { x: 1.0 / 1, y: 1.0 / 1 };
```

Which makes the removed lines completely pointless.

I am unsure whether the following is even needed after removing this, but leaving it in due to the uncertainty:

```js
sceneItem.scale = { x: 1.0, y: 1.0 };
```