### PR TITLE
Make finding resolutions more robust

### DIFF
--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -574,13 +574,6 @@ const defaultAudioDevice = (cfg: ElectronStore, deviceType: string): string => {
     }    
 }
 
-/*
-* Checks if val is +-2 to compare.
-*/
-const isNumberClose = (val: number, compare: number) => {
-    return Math.abs(compare - val) <= 2;
-};
-
 export {
     loadAllVideos,
     writeMetadataFile,
@@ -599,6 +592,5 @@ export {
     defaultMinEncounterDuration,
     defaultAudioDevice,
     addColor,
-    isNumberClose,
     getSortedVideos,
 };


### PR DESCRIPTION
The previous method of checking if a number was close to another number was a bit fuzzy.

This change introduces a new method `getClosestResolution()` which, given an array of available resolutions from OBS and a target resolution to match, will return the one that _closest_ match.

This means we'll _never_ crash due to not being able to find a resolution that matches, as it'll always return the one that closest match.

`isNumberClose()` has been removed due to this.

To prove that this works as good, and better, than the method with `isNumberClose()` (which was prone to errors when scaling goes up), here's an example from issue #123 where the reporter has a 4K monitor with 3840x2160 resolution and 175% scaling in Windows:

I added some extra resolutions to the array of available resolutions (5K & 8K) so his resolution wouldn't be the highest:
```
[
    '1920x1080',
    '1280x720',
    '2560x1440',
    '3840x2160',
    '5120x2880',
    '7680x4320'
]
```
```
00:52:49.349 > [OBS] Displays: [
    {
      id: 2841568472,
      bounds: { x: 0, y: 0, width: 2195, height: 1235 },
      workArea: { x: 0, y: 0, width: 2195, height: 1195 },
      accelerometerSupport: 'unknown',
      monochrome: false,
      colorDepth: 24,
      colorSpace: '{primaries:BT709, transfer:SRGB, matrix:RGB, range:FULL}',
      depthPerComponent: 8,
      size: { width: 2195, height: 1235 },
      displayFrequency: 60,
      workAreaSize: { width: 2195, height: 1195 },
      scaleFactor: 1.75,
      rotation: 0,
      internal: false,
      touchSupport: 'unknown'
    }
]
00:52:49.350 > { width: 3841.25, height: 2161.25 }
00:52:49.351 > 3840x2160
00:52:49.351 > [OBS] OBS: setSetting Video Base 3840x2160
```
See that it finds the resolution that closest match the calculated one.