### PR TITLE
Fix breaking change to `splitLogLine()`

### DIFF
--- a/src/main/combatLogParser.ts
+++ b/src/main/combatLogParser.ts
@@ -154,17 +154,17 @@ class LogLine {
                     }
 
                     value = '';
-                    break;
+                    continue;
 
                 case '"':
                     inQuotedString = true;
-                    break;
+                    continue;
 
                 case '[':
                 case '(':
                     listItems.push([]);
                     openListCount++;
-                    break;
+                    continue;
 
                 case ']':
                 case ')':
@@ -178,10 +178,8 @@ class LogLine {
 
                     value = listItems.pop();
                     openListCount--;
-                    break;
+                    continue;
                 }
-
-                continue;
             }
 
             value += char;


### PR DESCRIPTION
In an attempt to make TypeScript happy, all `continue` statements in the block of `switch (char) {` were changed to `break` with a single continue at the end.

This had the unfortunate consequence that it didn't parse anything because it never added non-special characters to the `value` variable.

This fixes that.