### PR TITLE
Fix unable to test record with 2v2 disabled

### DIFF
--- a/src/main/configService.ts
+++ b/src/main/configService.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { EventEmitter } from "stream";
 import { CombatLogParser } from "./combatLogParser";
 
-type ConfigurationSchema = {
+export type ConfigurationSchema = {
     storagePath: string,
     bufferStoragePath?: string,
     retailLogPath?: string,
@@ -26,6 +26,8 @@ type ConfigurationSchema = {
     recordSoloShuffle: boolean,
     recordBattlegrounds: boolean,
 };
+
+export type ConfigurationSchemaKey = keyof ConfigurationSchema;
 
 /**
  * Config schema. 
@@ -138,6 +140,7 @@ const schema = {
 };
 
 export default class ConfigService extends EventEmitter {
+    // @ts-ignore 'schema' is "wrong", but it really isn't.
     private _store = new ElectronStore<ConfigurationSchema>({schema, name: 'config-v2'});
 
     constructor() {

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,3 +1,4 @@
+import { ConfigurationSchemaKey } from "./configService";
 import { NumberKeyToStringValueMapType, RaidInstanceType } from "./types";
 
 enum VideoCategory {
@@ -10,7 +11,7 @@ enum VideoCategory {
   Battlegrounds = 'Battlegrounds',
 };
 
-const categories: string[] = [
+const categories: VideoCategory[] = [
   VideoCategory.TwoVTwo,
   VideoCategory.ThreeVThree,
   VideoCategory.Skirmish,
@@ -20,28 +21,50 @@ const categories: string[] = [
   VideoCategory.Battlegrounds,
 ];
 
-const categoryRecordConfigMapping: { [key in VideoCategory]: string } = {
-  [VideoCategory.TwoVTwo]: "recordTwoVTwo",
-  [VideoCategory.ThreeVThree]: "recordThreeVThree",
-  [VideoCategory.Skirmish]: "recordSkirmish",
-  [VideoCategory.SoloShuffle]: "recordSoloShuffle",
-  [VideoCategory.MythicPlus]:"recordRaids", // not used
-  [VideoCategory.Raids]: "recordDungeons", // not used
-  [VideoCategory.Battlegrounds]: "recordBattlegrounds",
+interface ICategoryRecordingSettings {
+  configKey: ConfigurationSchemaKey,
+  videoOverrun: number,
 };
 
 /**
- * How long to keep recording after an activity ends to ensure we don't miss any
- * important stuff at the end, per category, in seconds.
+ * Category specific settings for recording
+ *
+ * `configKey`:    The configuration key name that specifies if we're allowed
+ *                 to record content from that particular category.
+ *
+ * `videoOverrun`: Number of seconds of how long to keep recording after an
+ *                 activity ends to ensure we don't miss any important stuff
+ *                  at the end.
  */
-const videoOverrunPerCategory: { [key: string]: number } = {
-  [VideoCategory.TwoVTwo]: 3,
-  [VideoCategory.ThreeVThree]: 3,
-  [VideoCategory.Skirmish]: 3,
-  [VideoCategory.SoloShuffle]: 3,
-  [VideoCategory.MythicPlus]: 5,    // For the whole dungeon
-  [VideoCategory.Raids]: 15,        // Per boss encounter
-  [VideoCategory.Battlegrounds]: 3,
+const categoryRecordingSettings: { [key in VideoCategory]: ICategoryRecordingSettings } = {
+  [VideoCategory.TwoVTwo]: {
+    configKey: 'recordTwoVTwo',
+    videoOverrun: 4,
+  },
+  [VideoCategory.ThreeVThree]: {
+    configKey: 'recordThreeVThree',
+    videoOverrun: 4,
+  },
+  [VideoCategory.Skirmish]: {
+    configKey: 'recordSkirmish',
+    videoOverrun: 4,
+  },
+  [VideoCategory.SoloShuffle]: {
+    configKey: 'recordSoloShuffle',
+    videoOverrun: 4,
+  },
+  [VideoCategory.MythicPlus]:{
+    configKey: 'recordRaids',
+    videoOverrun: 5, // For the whole dungeon
+  },
+  [VideoCategory.Raids]: {
+    configKey: 'recordDungeons',
+    videoOverrun: 15, // Per boss encounter
+  },
+  [VideoCategory.Battlegrounds]: {
+    configKey: 'recordBattlegrounds',
+    videoOverrun: 3,
+  },
 };
 
 /**
@@ -546,7 +569,6 @@ export {
     instanceEncountersById,
     InstanceDifficultyType,
     VideoCategory,
-    videoOverrunPerCategory,
     raidInstances,
-    categoryRecordConfigMapping
+    categoryRecordingSettings,
 };


### PR DESCRIPTION
When the content type '2v2' is disabled, the test recording won't run because it runs a test on '2v2'.

This has been fixed by allowing a recording to take place even if we're not allowed to record the test content type, as long as `testRunning` is true.

Refactored `categoryRecordConfigMapping` into
`categoryRecordingSettings`, since we already had a similar object for 'overrun' (`videoOverrunPerCategory`). These have been merged and renamed.

In logutils, the logic regading the allowance of recording content types has been centralised into `allowRecordCategory()`, which also takes `testRunning` into account.

This method is used in `startRecording()` so there's a central place where this is checked and blocked, if needed.

Cleaned up some of the `console.log()` messages and removed the TODO regarding afk/hearth out as that has been fixed with the DataTimeout mechanism.