### PR TITLE
Make detection of WoW running better

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -544,6 +544,17 @@ const specializationById: { [id: number]: SpecializationObjectType } = {
   73:  { type: 'melee',  role: 'tank',   class: 'WARRIOR',     label: 'Warrior',      name: 'Protection' },
 };
 
+/**
+ * A map of WoW executable names to the appropriate WoW flavour
+ */
+const wowExecutableFlavours: { [key: string]: string } = {
+  'wow':        'Retail',
+  'wowt':       'PTR',
+  'wowb':       'Beta',
+  'wowclassic': 'Classic',
+};
+type WoWProcessResultKey = keyof typeof wowExecutableFlavours;
+
 export {
     categories,
     months,
@@ -571,4 +582,6 @@ export {
     VideoCategory,
     raidInstances,
     categoryRecordingSettings,
+    wowExecutableFlavours,
+    WoWProcessResultKey,
 };

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,4 +1,5 @@
 import { Size } from "electron";
+import { WoWProcessResultKey } from "./constants";
 
 /**
  * Application status
@@ -113,6 +114,11 @@ type FileInfo = {
     mtime: number;
 };
 
+interface IWoWProcessResult {
+    exe: string,
+    flavour: WoWProcessResultKey,
+};
+
 export {
     AppStatus,
     UnitFlags,
@@ -124,4 +130,5 @@ export {
     RaidInstanceType,
     FileInfo,
     FileFinderCallbackType,
+    IWoWProcessResult,
 }


### PR DESCRIPTION
- Detect any known version of WoW:
    - Wow.exe
    - WowB.exe
    - WowT.exe
    - WowClassic.exe

- Any version of WoW will keep the app thinking WoW is running, that is if you start Wow.exe, then start WowClassic.exe, then close Wow.exe it will keep monitoring log files because Classic is still running.