### PR TITLE
Feature: Configurable OBS recording encoder

### DIFF
--- a/src/main/configSchema.ts
+++ b/src/main/configSchema.ts
@@ -14,6 +14,8 @@ export type ConfigurationSchema = {
     obsBaseResolution: string,
     obsOutputResolution: string,
     obsFPS: number,
+    obsRecEncoder: string,
+    obsRecBitrate: number,
     recordRetail: boolean,
     recordClassic: boolean,
     recordRaids: boolean,
@@ -111,6 +113,18 @@ export const configSchema = {
         default: 60,
         minimum: 15,
         maximum: 60,
+    },
+    obsRecEncoder: {
+        description: "The video encoder to use for creating video files. If you don't know what this means, leave it on 'Automatic' to select the best option automatically.",
+        type: 'string',
+        default: 'auto',
+    },
+    obsRecBitrate: {
+        description: "The constant bitrate to record at. If you don't know what this means, leave it as-is.",
+        type: 'integer',
+        default: 50000,
+        minimum: 20000,
+        maximum: 35000000,
     },
     recordRetail: {
         description: 'Whether the application should record retail',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -65,6 +65,8 @@ const loadRecorderOptions = (cfg: ConfigService): RecorderOptionsType => {
     obsBaseResolution:    cfg.get<string>('obsBaseResolution'),
     obsOutputResolution:  cfg.get<string>('obsOutputResolution'),
     obsFPS:               cfg.get<number>('obsFPS'),
+    obsRecEncoder:        cfg.get<string>('obsRecEncoder'),
+    obsRecBitrate:        cfg.get<number>('obsRecBitrate'),
   };
 };
 

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -20,6 +20,8 @@ type RecorderOptionsType = {
     obsBaseResolution: string,
     obsOutputResolution: string,
     obsFPS: number;
+    obsRecEncoder: string,
+    obsRecBitrate: number,
 };
 
 /**

--- a/src/settings/AdvancedSettings.tsx
+++ b/src/settings/AdvancedSettings.tsx
@@ -8,8 +8,10 @@ import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { configSchema } from '../main/configSchema'
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
 const ipc = window.electron.ipcRenderer;
+const obsAvailableEncoders: string[] = ipc.sendSync('settingsWindow', ['getObsAvailableRecEncoders']);
 
 export default function GeneralSettings() {
 
@@ -31,13 +33,24 @@ export default function GeneralSettings() {
 
   const style = {
     width: '405px',
-    "& .MuiOutlinedInput-root": {
-      "&.Mui-focused fieldset": {borderColor: "#bb4220"},
-      "& > fieldset": {borderColor: "black" }
+    color: 'white',
+    '& .MuiOutlinedInput-notchedOutline': {
+      borderColor: 'black'
     },
-    "& .MuiInputLabel-root": {color: 'white'},
-    "& label.Mui-focused": {color: "#bb4220"},
-  }   
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderColor: '#bb4220'
+    },
+    '&.Mui-focused': {
+      borderColor: '#bb4220',
+      color: '#bb4220'
+    },
+    "& .MuiInputLabel-root": {
+      color: 'white'
+    },
+    '& .MuiFormHelperText-root:not(.Mui-error)': {
+      display: 'none'
+    },
+  }
 
   return (
     <Stack
@@ -65,6 +78,7 @@ export default function GeneralSettings() {
           </IconButton>
         </Tooltip>
       </Box>
+
       <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
         <TextField 
           value={config.minEncounterDuration}
@@ -79,7 +93,54 @@ export default function GeneralSettings() {
           sx={{...style, my: 1}}
           inputProps={{ style: { color: "white" } }}
         />
-        <Tooltip title={configSchema["minEncounterDuration"].description} sx={{position: 'fixed', left: '572px', top: '140px'}} >
+        <Tooltip title={configSchema["minEncounterDuration"].description}>
+          <IconButton>
+            <InfoIcon style={{ color: 'white' }}/>
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
+        <FormControl sx={{my: 1}}>
+          <InputLabel id="obs-rec-encoder-label" sx = {style}>Video recording encoder</InputLabel>
+          <Select
+            labelId="obs-rec-encoder-label"
+            id="obs-rec-encoder"
+            value={config.obsRecEncoder}
+            label="Video recording encoder"
+            onChange={(event) => modifyConfig('obsRecEncoder', event.target.value)}
+            sx={style}
+          >
+            { obsAvailableEncoders.map((recEncoder: any) =>
+              <MenuItem key={ 'rec-encoder-' + recEncoder.id } value={ recEncoder.id }>
+                { recEncoder.name }
+              </MenuItem>
+            )}
+          </Select>
+
+        </FormControl>
+        <Tooltip title={configSchema["obsRecEncoder"].description} >
+          <IconButton>
+            <InfoIcon style={{ color: 'white' }}/>
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
+        <TextField
+          value={config.obsRecBitrate}
+          onChange={event => { modifyConfig("obsRecBitrate", parseInt(event.target.value, 10)) }}
+          id="obs-rec-bitrate"
+          label="Recording Bitrate"
+          variant="outlined"
+          type="number"
+          error= { config.obsRecBitrate < 1 }
+          helperText={(config.obsRecBitrate < 1) ? "Must be positive" : ' '}
+          InputLabelProps={{ shrink: true }}
+          sx={{...style, my: 1}}
+          inputProps={{ style: { color: "white" } }}
+        />
+        <Tooltip title={configSchema["obsRecBitrate"].description}>
           <IconButton>
             <InfoIcon style={{ color: 'white' }}/>
           </IconButton>

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -33,6 +33,8 @@ export const configSettings = [
   'obsBaseResolution',
   'obsOutputResolution',
   'obsFPS',
+  'obsRecEncoder',
+  'obsRecBitrate',
 ];
 
 export default function useSettings() {
@@ -60,6 +62,8 @@ export default function useSettings() {
     obsBaseResolution:    getConfigValue<string>('obsBaseResolution'),
     obsOutputResolution:  getConfigValue<string>('obsOutputResolution'),
     obsFPS:               getConfigValue<number>('obsFPS'),
+    obsRecEncoder:        getConfigValue<string>('obsRecEncoder'),
+    obsRecBitrate:        getConfigValue<number>('obsRecBitrate'),
   });
 
   return [config, setConfig];


### PR DESCRIPTION
Adds configurable OBS Recording Encoder (`RecEncoder`) and bitrate (necessary for AMD AMF/x264).

Let's discuss it. Bitrate is required for AMD AMF and obs_x264 encoders but obviously changing between them, the bitrate might not mean the same. as in ... 50 kbit/s on AMD AMF might be better or worse than the same for obs_x264.

I made this change because a few people have suggested it.

Adresses issue #67. There are several ways of doing this, one is bitrate and the other is the simple version with "quality presets" which are slightly more difficult to implement, I believe.