### PR TITLE
Feature: Add Game Capture

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- [Issue 2](https://github.com/aza547/wow-recorder/issues/2) - Replace monitor capture with game capture.
+- [Issue 2](https://github.com/aza547/wow-recorder/issues/2) - Add Game Capture mode
 
 ### Changed
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [Issue 2](https://github.com/aza547/wow-recorder/issues/2) - Replace monitor capture with game capture.
+
 ### Changed
 ### Fixed
 

--- a/src/main/configSchema.ts
+++ b/src/main/configSchema.ts
@@ -15,6 +15,7 @@ export type ConfigurationSchema = {
     obsOutputResolution: string,
     obsFPS: number,
     obsKBitRate: number,
+    obsCaptureMode: string, // 'game_capture' or 'monitor_capture'
     recordRetail: boolean,
     recordClassic: boolean,
     recordRaids: boolean,
@@ -119,6 +120,11 @@ export const configSchema = {
         default: 10,
         minimum: 1,
         maximum: 300,
+    },
+    obsCaptureMode: {
+        description: 'How to record the game.',
+        type: 'string',
+        default: 'game_capture',
     },
     recordRetail: {
         description: 'Whether the application should record retail',

--- a/src/main/configSchema.ts
+++ b/src/main/configSchema.ts
@@ -122,7 +122,7 @@ export const configSchema = {
         maximum: 300,
     },
     obsCaptureMode: {
-        description: 'How to record the game.',
+        description: 'Game capture records the game directly but is limited in that only one OBS process can use game capture at a time. If you are also streaming with OBS Studio you may wish to use monitor capture here.',
         type: 'string',
         default: 'game_capture',
     },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -72,6 +72,7 @@ const loadRecorderOptions = (cfg: ConfigService): RecorderOptionsType => {
     obsOutputResolution:  cfg.get<string>('obsOutputResolution'),
     obsFPS:               cfg.get<number>('obsFPS'),
     obsKBitRate:          cfg.get<number>('obsKBitRate'),
+    obsCaptureMode:       cfg.get<string>('obsCaptureMode'),
   };
 };
 

--- a/src/main/obsRecorder.ts
+++ b/src/main/obsRecorder.ts
@@ -2,26 +2,28 @@ import { fixPathWhenPackaged, getAvailableDisplays } from "./util";
 import WaitQueue from 'wait-queue';
 import { getAvailableAudioInputDevices, getAvailableAudioOutputDevices } from "./obsAudioDeviceUtils";
 import { RecorderOptionsType } from "./recorder";
-import { OurDisplayType } from "./types";
 import { Size } from "electron";
-import { IScene } from "obs-studio-node";
 import path from 'path';
+import { inspectObject } from "./helpers";
+import { ISceneItem, IScene, IInput } from "obs-studio-node";
+import { OurDisplayType } from "./types";
+import { ISource } from "obs-studio-node";
 const waitQueue = new WaitQueue<any>();
 const osn = require("obs-studio-node");
 const { v4: uuid } = require('uuid');
 
 let obsInitialized = false;
-let scene = null;
+// Timer for periodically checking the size of the video source
+let timerVideoSourceSize: any;
+// Previous size of the video source as checked by checkVideoSourceSize()
+let lastVideoSourceSize: Size;
 
 /*
 * Reconfigure the recorder without destroying it.
 */
 const reconfigure = (options: RecorderOptionsType) => {
-  const baseResolution = parseResolutionsString(options.obsBaseResolution);
-  const outputResolution = parseResolutionsString(options.obsOutputResolution);
-
   configureOBS(options);
-  scene = setupScene(options.monitorIndex, baseResolution, outputResolution);
+  const scene = setupScene(options);
   setupSources(scene, options.audioInputDeviceId, options.audioOutputDeviceId);
 }
 
@@ -116,6 +118,7 @@ const configureOBS = (options: RecorderOptionsType) => {
   console.debug('[OBS] OBS Configured');
 }
 
+
 /*
 * Get information about primary display
 * @param zero starting monitor index
@@ -158,12 +161,12 @@ const getClosestResolution = (resolutions: string[], target: Size): string => {
 };
 
 /*
-* Given a none-whole monitor resolution, find the closest one that 
+* Given a none-whole monitor resolution, find the closest one that
 * OBS supports and set the corospoding setting in Video.Untitled.{paramString}
-* 
+*
 * @remarks
-* Useful when windows scaling is not set to 100% (125%, 150%, etc) on higher resolution monitors, 
-* meaning electron screen.getAllDisplays() will return a none integer scaleFactor, causing 
+* Useful when windows scaling is not set to 100% (125%, 150%, etc) on higher resolution monitors,
+* meaning electron screen.getAllDisplays() will return a none integer scaleFactor, causing
 * the calucated monitor resolution to be none-whole.
 *
 * @throws
@@ -174,44 +177,132 @@ const setOBSVideoResolution = (res: Size, paramString: string) => {
   const closestResolution = getClosestResolution(availableResolutions, res);
 
   setSetting('Video', paramString, closestResolution);
-}
+};
 
 /*
 * setupScene
 */
-const setupScene = (monitorIndex: number, baseResolution: Size, outputResolution: Size): IScene => {
+const setupScene = (options: RecorderOptionsType): IScene => {
+  const outputResolution = parseResolutionsString(options.obsOutputResolution);
+  let baseResolution: Size;
+
   setOBSVideoResolution(outputResolution, 'Output');
 
-  // Correct the monitorIndex. In config we start a 1 so it's easy for users. 
-  const monitorIndexFromZero = monitorIndex - 1;
-  console.info("[OBS] monitorIndexFromZero:", monitorIndexFromZero);
-  const selectedDisplay = displayInfo(monitorIndexFromZero);
-  if (!selectedDisplay) {
-    throw Error(`[OBS] No such display with index: ${monitorIndexFromZero}.`)
+  let videoSource: IInput;
+
+  switch (options.obsCaptureMode) {
+    case 'monitor_capture':
+      // Correct the monitorIndex. In config we start a 1 so it's easy for users.
+      const monitorIndexFromZero = options.monitorIndex - 1;
+      console.info("[OBS] monitorIndexFromZero:", monitorIndexFromZero);
+      const selectedDisplay = displayInfo(monitorIndexFromZero);
+      if (!selectedDisplay) {
+        throw Error(`[OBS] No such display with index: ${monitorIndexFromZero}.`)
+      }
+
+      baseResolution = selectedDisplay.physicalSize;
+
+      videoSource = createMonitorCaptureSource(monitorIndexFromZero);
+      break;
+
+    case 'game_capture':
+      baseResolution = outputResolution;
+      videoSource = createGameCaptureSource();
+      break;
+
+    default:
+      throw Error(`[OBS] Invalid capture mode: ${options.obsCaptureMode}`);
   }
 
-  setOBSVideoResolution(selectedDisplay.physicalSize, 'Base');
+  setOBSVideoResolution(baseResolution, 'Base');
 
-  const videoSource = osn.InputFactory.create('monitor_capture', 'desktop-video');
-
-  // Update source settings:
-  let settings = videoSource.settings;
-  settings['monitor'] = monitorIndexFromZero;
-  videoSource.update(settings);
-  videoSource.save();
-
-  // A scene is necessary here to properly scale captured screen size to output video size
-  const scene = osn.SceneFactory.create('test-scene');
+  const scene: IScene = osn.SceneFactory.create('test-scene');
   const sceneItem = scene.add(videoSource);
   sceneItem.scale = { x: 1.0, y: 1.0 };
 
+  console.log(`[OBS] Configured video input source with mode '${options.obsCaptureMode}'`, inspectObject(videoSource.settings))
+
+  watchVideoSourceSize(sceneItem, videoSource, baseResolution);
+
   return scene;
 }
+
+/**
+ * Create and return a game capture video source ('game_capture')
+ */
+const createGameCaptureSource = (): IInput => {
+  const videoSource = osn.InputFactory.create('game_capture', 'Game Capture');
+  const settings = videoSource.settings;
+
+  settings['capture_cursor'] = true;
+  settings['capture_mode'] = 'window';
+  settings['allow_transparency'] = true;
+  settings['priority'] = 1; // Window title must match
+  settings['window'] = 'World of Warcraft:GxWindowClass:Wow.exe';
+
+  videoSource.update(settings);
+  videoSource.save();
+
+  return videoSource;
+};
+
+/**
+ * Create and return a monitor capture video source ('monitor_capture')
+ */
+const createMonitorCaptureSource = (monitorIndex: number): IInput => {
+  const videoSource = osn.InputFactory.create('monitor_capture', 'Monitor Capture');
+  const settings = videoSource.settings;
+
+  settings['monitor'] = monitorIndex;
+
+  videoSource.update(settings);
+  videoSource.save();
+
+  return videoSource;
+};
+
+/**
+ * Watch the video input source for size changes and adjust the scene item
+ * scaling accordingly.
+ *
+ * @param sceneItem       Scene item as returned from `IScene.add()`
+ * @param sourceName      Video input source
+ * @param baseResolution  Resolution used as base for scaling the video source
+ */
+const watchVideoSourceSize = (sceneItem: ISceneItem, videoSource: IInput, baseResolution: Size): void => {
+  clearInterval(timerVideoSourceSize);
+  timerVideoSourceSize = setInterval(() => {
+    const result = { width: videoSource.width, height: videoSource.height };
+
+    if (result.width === 0 || result.height === 0) {
+      return;
+    }
+
+    if (lastVideoSourceSize && result.width === lastVideoSourceSize.width && result.height === lastVideoSourceSize.height) {
+      return;
+    }
+
+    lastVideoSourceSize = result;
+
+    const scaleFactor = baseResolution.width / result.width;
+    sceneItem.scale = { x: scaleFactor, y: scaleFactor };
+
+    const logDetails = {
+      base: baseResolution,
+      input: result,
+      scale: sceneItem.scale,
+    };
+
+    console.log("[OBS] Adjusting scene item scale due to video input source size change", inspectObject(logDetails));
+  }, 5000);
+};
 
 /*
 * setupSources
 */
 const setupSources = (scene: any, audioInputDeviceId: string, audioOutputDeviceId: string ) => {
+  clearSources();
+
   osn.Global.setOutputSource(1, scene);
 
   setSetting('Output', 'Track1Name', 'Mixed: all sources');
@@ -243,6 +334,26 @@ const setupSources = (scene: any, audioInputDeviceId: string, audioOutputDeviceI
 
   setSetting('Output', 'RecTracks', parseInt('1'.repeat(currentTrack-1), 2)); // Bit mask of used tracks: 1111 to use first four (from available six)
 }
+
+/**
+ * Clear all sources from the global output of OBS
+ */
+ const clearSources = (): void => {
+  console.log("[OBS] Removing all output sources")
+
+  // OBS allows a maximum of 64 output sources
+  for (let index = 1; index < 64; index++) {
+    const src: ISource = osn.Global.getOutputSource(index);
+    if (src !== undefined) {
+      setSetting('Output', `Track${index}Name`, '');
+      osn.Global.setOutputSource(index, null);
+      src.release();
+      src.remove();
+    }
+  }
+
+  setSetting('Output', 'RecTracks', 0); // Bit mask of used tracks: 1111 to use first four (from available six)
+};
 
 /*
 * start

--- a/src/main/obsRecorder.ts
+++ b/src/main/obsRecorder.ts
@@ -216,7 +216,7 @@ const setupScene = (options: RecorderOptionsType): IScene => {
 
   setOBSVideoResolution(baseResolution, 'Base');
 
-  const scene: IScene = osn.SceneFactory.create('test-scene');
+  const scene: IScene = osn.SceneFactory.create('main');
   const sceneItem = scene.add(videoSource);
   sceneItem.scale = { x: 1.0, y: 1.0 };
 

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -29,6 +29,7 @@ type RecorderOptionsType = {
     obsOutputResolution: string,
     obsFPS: number;
     obsKBitRate: number;
+    obsCaptureMode: string;
 };
 
 /**

--- a/src/settings/VideoSettings.tsx
+++ b/src/settings/VideoSettings.tsx
@@ -19,8 +19,8 @@ const { Base: baseResolutions, Output: outputResolutions } = obsResolutions;
 
 const fpsOptions = ['10', '20', '30', '60'];
 const obsCaptureModes = {
-  'game_capture': 'Game (best)',
-  'monitor_capture': 'Monitor'
+  'game_capture': 'Game Capture (Recommended)',
+  'monitor_capture': 'Monitor Capture'
 };
 
 export default function VideoSettings() {

--- a/src/settings/VideoSettings.tsx
+++ b/src/settings/VideoSettings.tsx
@@ -18,6 +18,10 @@ const obsResolutions: any = ipc.sendSync('settingsWindow', ['getObsAvailableReso
 const { Base: baseResolutions, Output: outputResolutions } = obsResolutions;
 
 const fpsOptions = ['10', '20', '30', '60'];
+const obsCaptureModes = {
+  'game_capture': 'Game (best)',
+  'monitor_capture': 'Monitor'
+};
 
 export default function VideoSettings() {
   const [config, setConfig] = React.useContext(ConfigContext);
@@ -59,13 +63,39 @@ export default function VideoSettings() {
     >
       <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
         <FormControl sx={{my: 1}}>
+          <InputLabel id="obs-capture-mode-label" sx = {style}>Capture Mode</InputLabel>
+          <Select
+            labelId="obs-capture-mode-label"
+            id="obs-capture-mode"
+            value={config.obsCaptureMode}
+            label="Capture Mode"
+            onChange={(event) => modifyConfig('obsCaptureMode', event.target.value)}
+            sx={style}
+          >
+            { Object.entries(obsCaptureModes).map((captureMode: any) =>
+              <MenuItem key={ 'capture-mode-' + captureMode[0] } value={ captureMode[0] }>
+                { captureMode[1] }
+              </MenuItem>
+            )}
+          </Select>
+        </FormControl>
+        <Tooltip title={configSchema["obsCaptureMode"].description} >
+          <IconButton>
+            <InfoIcon style={{ color: 'white' }}/>
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      { config.obsCaptureMode == 'monitor_capture' &&
+      <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
+        <FormControl sx={{my: 1}}>
           <InputLabel id="demo-simple-select-label" sx = {style}>Monitor</InputLabel>
           <Select
             labelId="demo-simple-select-label"
             id="monitor-index"
             value={config.monitorIndex}
             label="Monitor"
-            onChange={(event) => modifyConfig('monitorIndex', event.target.value)} 
+            onChange={(event) => modifyConfig('monitorIndex', event.target.value)}
             sx={style}
           >
             { displayConfiguration.map((display: OurDisplayType) =>
@@ -81,6 +111,7 @@ export default function VideoSettings() {
           </IconButton>
         </Tooltip>
       </Box>
+      }
 
       <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
         <FormControl sx={{my: 1}}>

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -37,6 +37,7 @@ const configValues = {
   obsOutputResolution:  getConfigValue<string>('obsOutputResolution'),
   obsFPS:               getConfigValue<number>('obsFPS'),
   obsKBitRate:          getConfigValue<number>('obsKBitRate'),
+  obsCaptureMode:       getConfigValue<string>('obsCaptureMode'),
 };
 
 export default function useSettings() {


### PR DESCRIPTION
Replace monitor capture with game capture

- Add Settings for selecting recording mode (Game or Monitor)

- Create `createMonitorCaptureSource()`

- Create `createGameCaptureSource()` to create and configure an input source of `game_capture` with the appropriate settings for capturing any window named 'World of Warcraft'. This will also capture WowClassic.exe, WowB.exe, etc.

- Create `watchVideoSourceSize()` to periodically watch the video source for a change in its dimensions and adjust the scaling factor accordingly to fit the best in the selected output resolution.

Closes #2