### PR TITLE
Only record audio when recording to buffer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- [Issue 57](https://github.com/aza547/wow-recorder/issues/57) - Only enable audio sources when recording buffer to avoid Windows not being able to go into sleep mode.
 
 ## [2.10.0] - 2022-10-22
 ### Added
@@ -21,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Issue 206](https://github.com/aza547/wow-recorder/issues/206) - Bitrate label corrected say to Mbps. 
 - [Issue 208](https://github.com/aza547/wow-recorder/issues/208) - Fix to Warsong Gulch image.
 - [Issue 213](https://github.com/aza547/wow-recorder/issues/213) - Fix the application occasionally crashing when WoW is closed.
-- [Issue 57](https://github.com/aza547/wow-recorder/issues/57) - Only enable audio sources when recording buffer to avoid Windows not being able to go into sleep mode.
 
 ## [2.9.0] - 2022-10-11
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Issue 205](https://github.com/aza547/wow-recorder/issues/205) - Expose encoder in Advanced Settings.
 - [Issue 206](https://github.com/aza547/wow-recorder/issues/206) - Bitrate label corrected say to Mbps. 
 - [Issue 208](https://github.com/aza547/wow-recorder/issues/208) - Fix to Warsong Gulch image.
+- [Issue 57](https://github.com/aza547/wow-recorder/issues/57) - Only enable audio sources when recording buffer to avoid Windows not being able to go into sleep mode.
 
 ## [2.9.0] - 2022-10-11
 ### Added

--- a/src/main/obsRecorder.ts
+++ b/src/main/obsRecorder.ts
@@ -28,7 +28,6 @@ const reconfigure = (options: RecorderOptionsType) => {
 
   configureOBS();
   scene = setupScene();
-  setupSources();
 }
 
 /**

--- a/src/main/obsRecorder.ts
+++ b/src/main/obsRecorder.ts
@@ -97,7 +97,7 @@ const configureOBS = () => {
   console.debug('[OBS] Configuring OBS');
   setSetting('Output', 'Mode', 'Advanced');
 
-  setObsRecEncoder(options);
+  setObsRecEncoder(recorderOptions);
 
   // Set output path and video format.
   setSetting('Output', 'RecFilePath', recorderOptions.bufferStorageDir);

--- a/src/main/obsRecorder.ts
+++ b/src/main/obsRecorder.ts
@@ -346,13 +346,14 @@ const setupSources = () => {
  * Set the Output.RecTracks setting for OBS
  */
 const setRecTracks = (): void => {
-  if (currentObsTrack == 1) {
-    setSetting('Output', 'RecTracks', 0);
-    return;
-  }
+  let audioBitMask = 0;
 
   // Bit mask of used tracks: 1111 to use first four (from available six)
-  setSetting('Output', 'RecTracks', parseInt('1'.repeat(currentObsTrack - 1), 2));
+  if (currentObsTrack > 1) {
+    audioBitMask = parseInt('1'.repeat(currentObsTrack - 1), 2)
+  }
+
+  setSetting('Output', 'RecTracks', audioBitMask);
 };
 
 /**
@@ -379,6 +380,8 @@ const clearSources = (): void => {
     }
   }
 
+  // Clear the track number back to 1 (beginning) such that setupSources() will
+  // will start at the correct index.
   currentObsTrack = 1;
   setRecTracks();
 };


### PR DESCRIPTION
To avoid Windows not going to sleep because we keep a microphone open, this change introduces a mechanism for only enabling the sound sources when the buffer restarting is canceled, e.g. when a recording is 'started'.

This _can_ result in a few seconds of missing audio in the beginning of the recording, but I _feel_ that's a fair sacrifice.

It works like this:

Start:

- `recorder.start()`
- Cancel buffer restart
- Setup audio sources (`obsRecorder.setupAudioSources()`)

Stop:

- `recorder.stop()`
- `obsRecorder.stop()`
- Clear and release audio sources

Further, simplify the filtering and adding of audio sources.

Fixes #57 