### PR TITLE
Feature: Configurable OBS encoder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - [Issue 168](https://github.com/aza547/wow-recorder/issues/168) - Fix player combatant not being saved properly when a recording is forcibly ended.
+- [Issue 205](https://github.com/aza547/wow-recorder/issues/205) - Expose encoder in Advanced Settings.
 - [Issue 206](https://github.com/aza547/wow-recorder/issues/206) - Bitrate label corrected say to Mbps. 
 - [Issue 208](https://github.com/aza547/wow-recorder/issues/208) - Fix to Warsong Gulch image.
 

--- a/src/main/configSchema.ts
+++ b/src/main/configSchema.ts
@@ -16,6 +16,7 @@ export type ConfigurationSchema = {
     obsFPS: number,
     obsKBitRate: number,
     obsCaptureMode: string, // 'game_capture' or 'monitor_capture'
+    obsRecEncoder: string,
     recordRetail: boolean,
     recordClassic: boolean,
     recordRaids: boolean,
@@ -125,6 +126,11 @@ export const configSchema = {
         description: 'Game capture records the game directly but is limited in that only one OBS process can use game capture at a time. If you are also streaming with OBS Studio you may wish to use monitor capture here.',
         type: 'string',
         default: 'game_capture',
+    },
+    obsRecEncoder: {
+        description: "The video encoder to use for creating video files. If you don't know what this means, leave it on 'Automatic' to select the best option automatically.",
+        type: 'string',
+        default: 'auto',
     },
     recordRetail: {
         description: 'Whether the application should record retail',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -40,8 +40,8 @@ import { Recorder, RecorderOptionsType } from './recorder';
 import { getAvailableAudioInputDevices, getAvailableAudioOutputDevices } from './obsAudioDeviceUtils';
 import { RecStatus, VideoPlayerSettings } from './types';
 import ConfigService from './configService';
-import { getObsResolutions } from './obsRecorder';
 import { CombatLogParser } from './combatLogParser';
+import { getObsAvailableRecEncoders, getObsResolutions } from './obsRecorder';
 
 let recorder: Recorder;
 
@@ -436,6 +436,33 @@ ipcMain.on('settingsWindow', (event, args) => {
     }
 
     event.returnValue = getObsResolutions();
+    return;
+  }
+
+  if (args[0] === 'getObsAvailableRecEncoders') {
+    if (!recorder) {
+      event.returnValue = [];
+      return;
+    }
+
+    const obsEncoders = getObsAvailableRecEncoders();
+    const defaultEncoder = obsEncoders.at(-1);
+    const encoderList = [{id: 'auto', name: `Automatic (${defaultEncoder})`}];
+
+    obsEncoders
+      // We don't want people to be able to select 'none'.
+      .filter(encoder => encoder !== 'none')
+      .forEach(encoder => {
+        const isHardwareEncoder = encoder.includes('amd') || encoder.includes('nvenc') || encoder.includes('qsv');
+        const encoderType = isHardwareEncoder ? 'Hardware' : 'Software';
+
+        encoderList.push({
+          id: encoder,
+          name: `${encoderType} (${encoder})`,
+        });
+      });
+
+    event.returnValue = encoderList;
     return;
   }
 })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -74,6 +74,7 @@ const loadRecorderOptions = (cfg: ConfigService): RecorderOptionsType => {
     obsFPS:               cfg.get<number>('obsFPS'),
     obsKBitRate:          cfg.get<number>('obsKBitRate'),
     obsCaptureMode:       cfg.get<string>('obsCaptureMode'),
+    obsRecEncoder:        cfg.get<string>('obsRecEncoder'),
   };
 };
 

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -312,9 +312,9 @@ type RecorderOptionsType = {
     /**
      * Shutdown OBS.
      */
-    shutdown = () => {
+    shutdown = async () => {
         if (this._isRecording) {
-            obsRecorder.stop();       
+            await obsRecorder.stop();
             this._isRecording = false;
         } else if (this._isRecordingBuffer) {
             this.stopBuffer()
@@ -327,7 +327,7 @@ type RecorderOptionsType = {
     /**
      * Reconfigure the underlying obsRecorder. 
      */
-    reconfigure = (options: RecorderOptionsType) => {
+    reconfigure = async (options: RecorderOptionsType) => {
         this._options = options;
 
         // User might just have shrunk the size, so run the size monitor.
@@ -337,7 +337,7 @@ type RecorderOptionsType = {
         });
       
         if (this._isRecording) {
-            obsRecorder.stop();       
+            await obsRecorder.stop();
             this._isRecording = false;
         } else if (this._isRecordingBuffer) {
             this.stopBuffer()

--- a/src/main/recorder.ts
+++ b/src/main/recorder.ts
@@ -30,6 +30,7 @@ type RecorderOptionsType = {
     obsFPS: number;
     obsKBitRate: number;
     obsCaptureMode: string;
+    obsRecEncoder: string,
 };
 
 /**

--- a/src/settings/AdvancedSettings.tsx
+++ b/src/settings/AdvancedSettings.tsx
@@ -8,8 +8,10 @@ import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { configSchema } from '../main/configSchema'
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
 const ipc = window.electron.ipcRenderer;
+const obsAvailableEncoders: string[] = ipc.sendSync('settingsWindow', ['getObsAvailableRecEncoders']);
 
 export default function GeneralSettings() {
 
@@ -31,13 +33,24 @@ export default function GeneralSettings() {
 
   const style = {
     width: '405px',
-    "& .MuiOutlinedInput-root": {
-      "&.Mui-focused fieldset": {borderColor: "#bb4220"},
-      "& > fieldset": {borderColor: "black" }
+    color: 'white',
+    '& .MuiOutlinedInput-notchedOutline': {
+      borderColor: 'black'
     },
-    "& .MuiInputLabel-root": {color: 'white'},
-    "& label.Mui-focused": {color: "#bb4220"},
-  }   
+    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+      borderColor: '#bb4220'
+    },
+    '&.Mui-focused': {
+      borderColor: '#bb4220',
+      color: '#bb4220'
+    },
+    "& .MuiInputLabel-root": {
+      color: 'white'
+    },
+    '& .MuiFormHelperText-root:not(.Mui-error)': {
+      display: 'none'
+    },
+  }
 
   return (
     <Stack
@@ -65,6 +78,7 @@ export default function GeneralSettings() {
           </IconButton>
         </Tooltip>
       </Box>
+
       <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
         <TextField 
           value={config.minEncounterDuration}
@@ -79,7 +93,33 @@ export default function GeneralSettings() {
           sx={{...style, my: 1}}
           inputProps={{ style: { color: "white" } }}
         />
-        <Tooltip title={configSchema["minEncounterDuration"].description} sx={{position: 'fixed', left: '572px', top: '140px'}} >
+        <Tooltip title={configSchema["minEncounterDuration"].description}>
+          <IconButton>
+            <InfoIcon style={{ color: 'white' }}/>
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
+        <FormControl sx={{my: 1}}>
+          <InputLabel id="obs-rec-encoder-label" sx = {style}>Video recording encoder</InputLabel>
+          <Select
+            labelId="obs-rec-encoder-label"
+            id="obs-rec-encoder"
+            value={config.obsRecEncoder}
+            label="Video recording encoder"
+            onChange={(event) => modifyConfig('obsRecEncoder', event.target.value)}
+            sx={style}
+          >
+            { obsAvailableEncoders.map((recEncoder: any) =>
+              <MenuItem key={ 'rec-encoder-' + recEncoder.id } value={ recEncoder.id }>
+                { recEncoder.name }
+              </MenuItem>
+            )}
+          </Select>
+
+        </FormControl>
+        <Tooltip title={configSchema["obsRecEncoder"].description} >
           <IconButton>
             <InfoIcon style={{ color: 'white' }}/>
           </IconButton>

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -38,6 +38,7 @@ const configValues = {
   obsFPS:               getConfigValue<number>('obsFPS'),
   obsKBitRate:          getConfigValue<number>('obsKBitRate'),
   obsCaptureMode:       getConfigValue<string>('obsCaptureMode'),
+  obsRecEncoder:        getConfigValue<string>('obsRecEncoder'),
 };
 
 export default function useSettings() {


### PR DESCRIPTION
Add OBS recording encoder setting

- Add `obsRecEncoder` to config schema and "Advanced Settings"

- Defaults to 'auto', which keeps the old logic of taking the last encoder of the list of available encoders.

- Fix race condition in stop/reconfigure obsRecorder due to not waiting for `obsrecorder.stop()` before calling `obsRecorder.reconfigure()`.

- Add Settings UI elements and helper functions

- Add styling to avoid the dropdown selector having black border/text

Fixes #205