### PR TITLE
Fix player combatant not saved properly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
-- Fix player combatant not being saved properly when a recording is forcibly ended.
+- [Issue 168](https://github.com/aza547/wow-recorder/issues/168) - Fix player combatant not being saved properly when a recording is forcibly ended.
 - [Issue 206](https://github.com/aza547/wow-recorder/issues/206) - Bitrate label corrected say to Mbps. 
 
 ## [2.9.0] - 2022-10-11

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fix player combatant not being saved properly when a recording is forcibly ended.
 - [Issue 206](https://github.com/aza547/wow-recorder/issues/206) - Bitrate label corrected say to Mbps. 
 
 ## [2.9.0] - 2022-10-11

--- a/src/main/logutils.ts
+++ b/src/main/logutils.ts
@@ -191,12 +191,6 @@ const endRecording = (options?: EndRecordingOptionsType) => {
     metadata.duration = Math.round(videoDuration / 1000) + overrun;
     metadata.result = options?.result ?? false;
 
-    if (playerCombatant) {
-        metadata.playerName = playerCombatant.name;
-        metadata.playerRealm = playerCombatant.realm;
-        metadata.playerSpecID = playerCombatant.specID;
-    }
-
     console.log(`[Logutils] Stop recording video for category: ${currentActivity}`)
 
     recorder.stop(metadata, overrun);
@@ -496,6 +490,10 @@ function handleSpellAuraAppliedLine (line: LogLine): void {
         srcCombatant.name = srcName;
         srcCombatant.realm = srcRealm;
         playerCombatant = srcCombatant;
+
+        metadata.playerName = playerCombatant.name;
+        metadata.playerRealm = playerCombatant.realm;
+        metadata.playerSpecID = playerCombatant.specID;
     }
 }
 


### PR DESCRIPTION
When a recording is forcibly ended the player combatant isn't properly added to the metadata.