### PR TITLE
Feature: Validate WoW log directories

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [Issue 211](https://github.com/aza547/wow-recorder/issues/211) - Validate combat log paths to avoid mistakes.
 - [Issue 2](https://github.com/aza547/wow-recorder/issues/2) - Add Game Capture mode
 - [Issue 207](https://github.com/aza547/wow-recorder/issues/207) - Suggest some bitrates in the settings help text.
 

--- a/docs/LocateLogDirectory.md
+++ b/docs/LocateLogDirectory.md
@@ -1,0 +1,29 @@
+# How to find your World of Warcraft combat log directory
+
+It can be a bit confusing to find the right directory where your Warcraft combat logs are saved if you've never dealt with them before, so here's a quick step-by-step guide to how to find it for any flavour of Warcraft.
+
+# Instructions
+
+1. Open the Battle.net Launcher
+
+2. Select the version of WoW you want to record
+
+3. Click the gear-icon to the right of the "_Play_" button
+
+4. Click on "_Show in Explorer_"<br/>
+   ![](https://i.imgur.com/7Pf5Dk2.png)
+
+5. Double-click on the flavour of WoW you want to record. One of `_classic`, `_retail_`, `_ptr_`, or `_beta_`<br/>
+  ![](https://i.imgur.com/5odiFIw.png)
+
+6. Double-click the folder `Logs`<br/>
+  ![](https://i.imgur.com/TRWVpko.png)
+
+7. Right click the address bar in Explorer and copy the location<br/>
+  ![](https://i.imgur.com/4pegWpB.png)
+
+8. This location can be pasted into the folder selection box in Warcraft Recorder
+
+# Tips
+
+If you're using Windows 11, you can stop at step 6 and simply right click the `Logs` folder and select "_Copy as path_".

--- a/src/main/combatLogParser.ts
+++ b/src/main/combatLogParser.ts
@@ -303,6 +303,23 @@ class CombatLogParser extends EventEmitter {
     }
 
     /**
+     * Validate a path as a combat log path
+     */
+    static validateLogPath(pathSpec: string): boolean {
+        pathSpec = path.resolve(pathSpec);
+
+        // Check if the leaf node of the path is actually 'logs',
+        // which _all_ WoW flavours use for logs.
+        const pathLeaf = path.basename(pathSpec).toLowerCase();
+        if (pathLeaf !== 'logs') {
+            return false;
+        }
+
+        // Check if the parent directory has a WoW flavour info file
+        return CombatLogParser.getWowFlavour(pathSpec) !== 'unknown'
+    }
+
+    /**
      * Find and return the flavour of WoW that the log directory
      * belongs to by means of the '.flavor.info' file.
      */
@@ -311,7 +328,7 @@ class CombatLogParser extends EventEmitter {
             path.join(pathSpec, '../.flavor.info')
         );
 
-        // If this file doesn't exist, it's not a WoW combat log directory
+        // If this file doesn't exist, it's not a subdirectory of a WoW flavour.
         if (!fs.existsSync(flavourInfoFile)) {
             return 'unknown';
         }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -41,6 +41,7 @@ import { getAvailableAudioInputDevices, getAvailableAudioOutputDevices } from '.
 import { RecStatus, VideoPlayerSettings } from './types';
 import ConfigService from './configService';
 import { getObsResolutions } from './obsRecorder';
+import { CombatLogParser } from './combatLogParser';
 
 let recorder: Recorder;
 
@@ -304,7 +305,15 @@ const openPathDialog = (event: any, args: any) => {
   
   dialog.showOpenDialog(settingsWindow, { properties: ['openDirectory'] }).then(result => {
     if (!result.canceled) {
-      event.reply('settingsWindow', ['pathSelected', setting, result.filePaths[0]]);
+      const selectedPath = result.filePaths[0];
+      let validationResult = true;
+
+      // Validate the path if it's a path for a log directory
+      if (setting === 'retailLogPath' || setting === 'classicLogPath') {
+        validationResult = CombatLogParser.validateLogPath(selectedPath);
+      }
+
+      event.reply('settingsWindow', ['pathSelected', setting, selectedPath, validationResult]);
     }
   })
   .catch(err => {

--- a/src/renderer/InformationDialog.tsx
+++ b/src/renderer/InformationDialog.tsx
@@ -5,6 +5,8 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
+import Container from '@mui/material/Container';
+import { makeStyles } from 'tss-react/mui';
 
 type ValidbuttonType = {
     label: string,
@@ -12,11 +14,11 @@ type ValidbuttonType = {
 };
 
 const validButtons: { [key: string]: ValidbuttonType } = {
+    'confirm': { label: 'Confirm', action: true },
     'yes':     { label: 'Yes',     action: true },
     'no':      { label: 'No',      action: false },
     'ok':      { label: 'OK',      action: false },
     'close':   { label: 'Close',   action: false },
-    'confirm': { label: 'Confirm', action: true },
 };
 type ValidButtonKeyType = keyof typeof validButtons;
 
@@ -24,14 +26,50 @@ type ConfirmationDialogProps = {
     open: boolean,
     title?: string,
     buttons: string[],
-    children?: string,
+    children?: React.ReactElement | React.ReactElement[],
     default?: string,
     onAction?: Function,
     onClose: Function,
 }
 
+/**
+ * Styles needed to make the dialog look similar to the rest of the app
+ */
+const useStyles = makeStyles()({
+    dialog: {
+        '.MuiDialog-paper': {
+            backgroundColor: '#272e48',
+            color: 'white',
+            '.MuiTypography-root': {
+                color: 'white',
+            },
+            'a': {
+                color: '#ffa78e',
+                '&:hover': {
+                    textDecoration: 'underline',
+                },
+            },
+            '.MuiDialogContent-root': {
+                padding: '8px 16px',
+            },
+            '.MuiDialogContentText-root': {
+                padding: '8px 0px',
+            },
+            '.MuiDialogActions-root': {
+                '.MuiButton-textPrimary': {
+                    color: 'white',
+                },
+                '.MuiButton-textSecondary': {
+                    color: '#ffa78e',
+                },
+            },
+        },
+    },
+})
+
 export default function InformationDialog(props: ConfirmationDialogProps) {
     const [open, setOpen] = React.useState(props.open);
+    const { classes: styles } = useStyles();
 
     const handleBtnClick = (button: ValidButtonKeyType) => {
         if (validButtons.hasOwnProperty(button) && validButtons[button].action) {
@@ -44,8 +82,8 @@ export default function InformationDialog(props: ConfirmationDialogProps) {
     };
 
     const renderButton = (button: ValidButtonKeyType, autoFocus: boolean) => {
-        return (
-            <Button key={'dialog-button-' + button} onClick={() => handleBtnClick(button)} autoFocus={autoFocus}>
+        return  (
+            <Button color={autoFocus ? 'primary' : 'secondary'} key={'dialog-button-' + button} onClick={() => handleBtnClick(button)} autoFocus={autoFocus}>
                 { validButtons[button].label }
             </Button>
         );
@@ -56,20 +94,18 @@ export default function InformationDialog(props: ConfirmationDialogProps) {
     }, [props.open])
 
     return (
-        <Dialog
+        <Dialog className={ styles.dialog }
             open={open}
-            aria-labelledby="alert-dialog-title"
-            aria-describedby="alert-dialog-description"
+            aria-labelledby="dialog-title"
+            aria-describedby="dialog-description"
         >
             { props.title &&
-                <DialogTitle id="alert-dialog-title">
+                <DialogTitle id="dialog-title">
                     { props.title }
                 </DialogTitle>
             }
-            <DialogContent>
-                <DialogContentText id="alert-dialog-description">
+            <DialogContent id="dialog-description">
                 { props.children }
-                </DialogContentText>
             </DialogContent>
             <DialogActions>
                 { props.buttons.map(button => renderButton(button, props.default === button || props.buttons.length == 1)) }

--- a/src/renderer/RecorderStatus.tsx
+++ b/src/renderer/RecorderStatus.tsx
@@ -6,6 +6,7 @@ import stopRecordingIcon from '../../assets/icon/stop-recording.png';
 import { useState, useEffect } from 'react';
 import { RecStatus } from 'main/types';
 import InformationDialog from './InformationDialog';
+import { DialogContentText } from '@mui/material';
 
 type IconStyle = 'small' | 'big';
 
@@ -77,7 +78,9 @@ export default function RecorderStatus() {
           onAction={stopRecording}
           onClose={closeDialog}
         >
-          Manually stopping the recording isn't usually a great idea, but it can be necessary if there's a bug that prevents it from stopping on its own.
+          <DialogContentText>
+            Manually stopping the recording isn't usually a great idea, but it can be necessary if there's a bug that prevents it from stopping on its own.
+          </DialogContentText>
         </InformationDialog>
       </div>
     </div>


### PR DESCRIPTION
Add validation for WoW combat log paths such that there will no longer be any confusion about what it is that needs to be selected.

Add a guide in `docs/` that thoroughly explains how to find the appropriate log directory.

Improved styling for the `<InformationDialog/>` component to bring it in line with the rest of the app.

Fixes #211 