### PR TITLE
Refactor modifyConfig()

### DIFF
--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -132,6 +132,31 @@ type VideoQueueItem = {
     metadata: Metadata,
 };
 
+interface IEventTarget {
+    name: string,
+    value: any,
+};
+
+/**
+ * Class to fake an event for onChange in `ISettingsPanelProps`
+ */
+class FakeChangeEvent {
+    public target: IEventTarget;
+
+    constructor(name: string, value: any) {
+        this.target = {name, value};
+    }
+}
+
+interface IOurChangeEvent {
+    target: IEventTarget;
+};
+
+interface ISettingsPanelProps {
+    config: any,
+    onChange: (event: IOurChangeEvent) => void,
+};
+
 export {
     RecStatus,
     SaveStatus,
@@ -146,4 +171,6 @@ export {
     FileFinderCallbackType,
     IWoWProcessResult,
     VideoQueueItem,
+    FakeChangeEvent,
+    ISettingsPanelProps,
 }

--- a/src/settings/AdvancedSettings.tsx
+++ b/src/settings/AdvancedSettings.tsx
@@ -2,34 +2,30 @@ import * as React from 'react';
 import { openDirectorySelectorDialog } from './settingUtils';
 import TextField from '@mui/material/TextField';
 import Stack from '@mui/material/Stack';
-import ConfigContext from "./ConfigContext";
 import Box from '@mui/material/Box';
 import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { configSchema } from '../main/configSchema'
 import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import { FakeChangeEvent, ISettingsPanelProps } from 'main/types';
 
 const ipc = window.electron.ipcRenderer;
 const obsAvailableEncoders: string[] = ipc.sendSync('settingsWindow', ['getObsAvailableRecEncoders']);
 
-export default function GeneralSettings() {
-
-  const [config, setConfig] = React.useContext(ConfigContext);
-
-  const modifyConfig = (stateKey: string, value: any) => {
-    setConfig((prevConfig: any) => ({ ...prevConfig, [stateKey]: value }));
-  };
+export default function GeneralSettings(props: ISettingsPanelProps) {
+  const { config } = props;
 
   /**
    * Event handler when user selects an option in dialog window.
    */
    React.useEffect(() => {
     ipc.on('settingsWindow', (args: any) => {
-      if (args[0] === "pathSelected") modifyConfig(args[1], args[2]);
+      if (args[0] === "pathSelected") {
+        props.onChange(new FakeChangeEvent(args[1], args[2]));
+      }
     });
   }, []);
-
 
   const style = {
     width: '405px',
@@ -62,7 +58,8 @@ export default function GeneralSettings() {
       autoComplete="off"
     >
       <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
-        <TextField 
+        <TextField
+          name="bufferStoragePath"
           value={config.bufferStoragePath}
           id="buffer-path" 
           label="Buffer Path" 
@@ -81,8 +78,9 @@ export default function GeneralSettings() {
 
       <Box component="span" sx={{ display: 'flex', alignItems: 'center'}}>
         <TextField 
+          name="minEncounterDuration"
           value={config.minEncounterDuration}
-          onChange={event => { modifyConfig("minEncounterDuration", parseInt(event.target.value, 10)) }}
+          onChange={props.onChange}
           id="max-storage" 
           label="Min Encounter Duration (sec)" 
           variant="outlined" 
@@ -104,11 +102,12 @@ export default function GeneralSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="obs-rec-encoder-label" sx = {style}>Video recording encoder</InputLabel>
           <Select
+            name="obsRecEncoder"
             labelId="obs-rec-encoder-label"
             id="obs-rec-encoder"
             value={config.obsRecEncoder}
             label="Video recording encoder"
-            onChange={(event) => modifyConfig('obsRecEncoder', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { obsAvailableEncoders.map((recEncoder: any) =>

--- a/src/settings/AudioSettings.tsx
+++ b/src/settings/AudioSettings.tsx
@@ -1,29 +1,21 @@
-import * as React from 'react';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import { ObsAudioDevice } from 'main/obsAudioDeviceUtils';
-import ConfigContext from "./ConfigContext";
 import Box from '@mui/material/Box';
 import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { configSchema } from '../main/configSchema'
+import { ISettingsPanelProps } from 'main/types';
 
 const ipc = window.electron.ipcRenderer;
 
-export default function GeneralSettings() {
-
-  const [config, setConfig] = React.useContext(ConfigContext);
-
-  const modifyConfig = (stateKey: string, value: any) => {
-    setConfig((prevConfig: any) => ({ ...prevConfig, [stateKey]: value }));
-  };
-
+export default function GeneralSettings(props: ISettingsPanelProps) {
+  const { config } = props;
   const audioDevices = ipc.sendSync('getAudioDevices', []);
-  console.log(audioDevices);
 
   const availableAudioDevices = {
     input: [
@@ -66,11 +58,12 @@ export default function GeneralSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="demo-simple-select-label" sx = {style}>Input</InputLabel>
           <Select
+            name="audioInputDevice"
             labelId="demo-simple-select-label"
             id="audio-input-device"
             value={config.audioInputDevice}
             label="Input"
-            onChange={(event) => modifyConfig('audioInputDevice', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { availableAudioDevices.input.map((device: ObsAudioDevice) => {
@@ -90,11 +83,12 @@ export default function GeneralSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="demo-simple-select-label" sx = {style}>Output</InputLabel>
           <Select
+            name="audioOutputDevice"
             labelId="demo-simple-select-label"
             id="audio-output-device"
             value={config.audioOutputDevice}
             label="Output"
-            onChange={(event) => modifyConfig('audioOutputDevice', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { availableAudioDevices.output.map((device: ObsAudioDevice) => {

--- a/src/settings/ConfigContext.ts
+++ b/src/settings/ConfigContext.ts
@@ -1,5 +1,0 @@
-import React from "react";
-                            // TODO should be config type as first arg here
-const ConfigContext = React.createContext<[any, React.Dispatch<any>]>([{}, () => {}]);
-
-export default ConfigContext;

--- a/src/settings/ContentSettings.tsx
+++ b/src/settings/ContentSettings.tsx
@@ -1,31 +1,20 @@
-import * as React from 'react';
 import Checkbox from '@mui/material/Checkbox';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Divider from '@mui/material/Divider';
 import FormLabel from '@mui/material/FormLabel';
-import ConfigContext from "./ConfigContext";
+import { ISettingsPanelProps } from 'main/types';
 
-export default function ContentSettings() {
-  const [config, setConfig] = React.useContext(ConfigContext);
+export default function ContentSettings(props: ISettingsPanelProps) {
+  const { config } = props;
 
-  const modifyConfig = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setConfig({
-      ...config,
-      [event.target.name]: event.target.checked,
-    });
-  };
-
-  const getCheckBox = (preference: string) => {
-    return (
-      <Checkbox 
-        checked={Boolean(config[preference])} 
-        onChange={modifyConfig} 
-        name={preference}
-        style = {checkBoxStyle} 
-      />
-    )
-  }
+  const getCheckBox = (preference: string) =>
+    <Checkbox
+      checked={Boolean(config[preference])}
+      onChange={props.onChange}
+      name={preference}
+      style={checkBoxStyle}
+    />;
 
   const checkBoxStyle = {color: "#bb4220", padding: 5};
   const formControlLabelStyle = {color: "white"};
@@ -37,23 +26,23 @@ export default function ContentSettings() {
       <FormLabel id="radios" sx={formLabelStyle}>Game Type</FormLabel>
       <Divider color="black" />
       <FormGroup sx={formGroupStyle}>
-        <FormControlLabel control={getCheckBox("recordRetail")} label="Retail" style = {formControlLabelStyle} />
-        <FormControlLabel control={getCheckBox("recordClassic")} label="Classic" style = {formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordRetail")} label="Retail" style={formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordClassic")} label="Classic" style={formControlLabelStyle} />
       </FormGroup>
       <FormLabel id="radios" sx={formLabelStyle}>PvE</FormLabel>
       <Divider color="black" />
       <FormGroup sx={formGroupStyle}>
-        <FormControlLabel control={getCheckBox("recordRaids")} label="Raids" style = {formControlLabelStyle} />
-        <FormControlLabel control={getCheckBox("recordDungeons")} label="Mythic+" style = {formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordRaids")} label="Raids" style={formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordDungeons")} label="Mythic+" style={formControlLabelStyle} />
       </FormGroup>
       <FormLabel id="radios" sx={formLabelStyle}>PvP</FormLabel>
       <Divider color="black" />
       <FormGroup sx={formGroupStyle}>
-        <FormControlLabel control={getCheckBox("recordTwoVTwo")} label="2v2" style = {formControlLabelStyle} />
-        <FormControlLabel control={getCheckBox("recordThreeVThree")} label="3v3" style = {formControlLabelStyle} />
-        <FormControlLabel control={getCheckBox("recordSkirmish")} label="Skirmish" style = {formControlLabelStyle} />
-        <FormControlLabel control={getCheckBox("recordSoloShuffle")} label="Solo Shuffle" style = {formControlLabelStyle} />
-        <FormControlLabel control={getCheckBox("recordBattlegrounds")} label="Battlegrounds" style = {formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordTwoVTwo")} label="2v2" style={formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordThreeVThree")} label="3v3" style={formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordSkirmish")} label="Skirmish" style={formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordSoloShuffle")} label="Solo Shuffle" style={formControlLabelStyle} />
+        <FormControlLabel control={getCheckBox("recordBattlegrounds")} label="Battlegrounds" style={formControlLabelStyle} />
       </FormGroup>
     </div>
   );

--- a/src/settings/GeneralSettings.tsx
+++ b/src/settings/GeneralSettings.tsx
@@ -5,7 +5,6 @@ import { openDirectorySelectorDialog } from './settingUtils';
 import Checkbox from '@mui/material/Checkbox';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import ConfigContext from "./ConfigContext";
 import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
@@ -13,26 +12,15 @@ import Box from '@mui/material/Box';
 import { configSchema } from '../main/configSchema'
 import InformationDialog from '../renderer/InformationDialog';
 import { DialogContentText } from '@mui/material';
+import { FakeChangeEvent, ISettingsPanelProps } from 'main/types';
 
 const ipc = window.electron.ipcRenderer;
 
-export default function GeneralSettings() {
-
-  const [config, setConfig] = React.useContext(ConfigContext);
+export default function GeneralSettings(props: ISettingsPanelProps) {
+  const { config } = props;
   const [openDialog, setDialog] = React.useState(false);
 
   const closeDialog = () => setDialog(false);
-
-  const modifyConfig = (stateKey: string, value: any) => {
-    setConfig((prevConfig: any) => ({ ...prevConfig, [stateKey]: value }));
-  };
-
-  const modifyCheckboxConfig = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setConfig({
-      ...config,
-      [event.target.name]: event.target.checked,
-    });
-  };
 
   /**
    * Event handler when user selects an option in dialog window.
@@ -49,7 +37,7 @@ export default function GeneralSettings() {
           }
         }
 
-        modifyConfig(setting, value);
+        props.onChange(new FakeChangeEvent(setting, value));
       }
     });
   }, []);
@@ -68,16 +56,13 @@ export default function GeneralSettings() {
   const formControlLabelStyle = {color: "white"};
   const formGroupStyle = {width: '48ch'};
 
-  const getCheckBox = (preference: string) => {
-    return (
-      <Checkbox 
-        checked={ config[preference] } 
-        onChange={modifyCheckboxConfig} 
-        name={preference}
-        style = {checkBoxStyle} 
-      />
-    )
-  };
+  const getCheckBox = (preference: string) =>
+    <Checkbox
+      checked={Boolean(config[preference])}
+      onChange={props.onChange}
+      name={preference}
+      style={checkBoxStyle}
+    />;
 
   const openLink = (url: string) => {
     ipc.sendMessage('openURL', [url]);
@@ -94,6 +79,7 @@ export default function GeneralSettings() {
     >
       <Box component="span" sx={{ display: 'flex', alignItems: 'flex-start' }}>
         <TextField 
+          name="storagePath"
           value={config.storagePath}
           id="storage-path" 
           label="Storage Path" 
@@ -129,16 +115,17 @@ export default function GeneralSettings() {
       </Box>
 
       <Box component="span" sx={{ display: 'flex', alignItems: 'flex-start' }}>
-      <TextField 
-        value={config.classicLogPath}
-        id="classic-log-path" 
-        label="Classic Log Path" 
-        variant="outlined" 
-        onClick={() => openDirectorySelectorDialog("classicLogPath")}
-        InputLabelProps={{ shrink: true }}
-        sx={{...style, my: 1}}
-        inputProps={{ style: { color: "white" } }}
-      />
+        <TextField
+          name="classicLogPath"
+          value={config.classicLogPath}
+          id="classic-log-path"
+          label="Classic Log Path"
+          variant="outlined"
+          onClick={() => openDirectorySelectorDialog("classicLogPath")}
+          InputLabelProps={{ shrink: true }}
+          sx={{...style, my: 1}}
+          inputProps={{ style: { color: "white" } }}
+        />
         <Tooltip title={configSchema["classicLogPath"].description} sx={{position: 'relative', right: '0px', top: '17px'}}>
           <IconButton>
             <InfoIcon style={{ color: 'white' }}/>
@@ -148,8 +135,9 @@ export default function GeneralSettings() {
 
       <Box component="span" sx={{ display: 'flex', alignItems: 'flex-start' }}>
         <TextField 
+          name="maxStorage"
           value={config.maxStorage}
-          onChange={event => { modifyConfig("maxStorage", parseInt(event.target.value, 10)) }}
+          onChange={props.onChange}
           id="max-storage" 
           label="Max Storage (GB)" 
           variant="outlined" 

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -9,8 +9,8 @@ import VideoSettings from './VideoSettings';
 import AudioSettings from './AudioSettings';
 import AdvancedSettings from './AdvancedSettings';
 import ContentSettings from './ContentSettings';
-import ConfigContext from "./ConfigContext";
 import useSettings, { setConfigValues } from "./useSettings";
+import { configSchema } from 'main/configSchema';
 
 const ipc = window.electron.ipcRenderer;
 
@@ -47,10 +47,28 @@ function a11yProps(index: number) {
   };
 }
 
-
 export default function Settings() {
   const [config, setConfig] = useSettings();
   const [tabIndex, setTabIndex] = React.useState(0);
+
+  const modifyConfig = (event: any): void => {
+    const setting = (event.target.name as keyof typeof configSchema);
+    let value = event.target.value;
+
+    switch (configSchema[setting].type) {
+      case 'integer':
+        value = parseInt(value, 10);
+        break;
+
+      case 'boolean':
+        value = event.target.checked;
+        break;
+    }
+
+    console.debug("Modify config", { setting, value });
+
+    setConfig((prevConfig: any) => ({ ...prevConfig, [setting]: value }));
+  }
 
   const handleChangeTab = (_event: React.SyntheticEvent, newValue: number) => {
     setTabIndex(newValue);
@@ -116,46 +134,44 @@ const useStyles = makeStyles()({
    const { classes: styles } = useStyles();
 
   return (
-    <ConfigContext.Provider value={[config, setConfig]}>
-      <Box
-        sx={{ flexGrow: 1, bgcolor: 'background.paper', display: 'flex', height: '100%' }}
+    <Box
+      sx={{ flexGrow: 1, bgcolor: 'background.paper', display: 'flex', height: '100%' }}
+    >
+      <Tabs
+        orientation="vertical"
+        variant="scrollable"
+        value={tabIndex}
+        onChange={handleChangeTab}
+        aria-label="Vertical tabs example"
+        sx= {{ ...categoryTabsSx }}
+        className={ styles.tabs }
+        TabIndicatorProps={{ style: { background:'#bb4220' } }}
       >
-        <Tabs
-          orientation="vertical"
-          variant="scrollable"
-          value={tabIndex}
-          onChange={handleChangeTab}
-          aria-label="Vertical tabs example"
-          sx= {{ ...categoryTabsSx }}
-          className={ styles.tabs }
-          TabIndicatorProps={{ style: { background:'#bb4220' } }}
-        >
-          <Tab label="General" {...a11yProps(0)} sx = {{ ...categoryTabSx }} />
-          <Tab label="Content" {...a11yProps(1)} sx = {{ ...categoryTabSx }}/>
-          <Tab label="Video" {...a11yProps(2)} sx = {{ ...categoryTabSx }}/>
-          <Tab label="Audio" {...a11yProps(3)} sx = {{ ...categoryTabSx }}/>
-          <Tab label="Advanced" {...a11yProps(4)} sx = {{ ...categoryTabSx }}/>
-        </Tabs>
-        <TabPanel value={tabIndex} index={0}>
-          <GeneralSettings/>
-        </TabPanel>
-        <TabPanel value={tabIndex} index={1}>
-          <ContentSettings/>
-        </TabPanel>
-        <TabPanel value={tabIndex} index={2}>
-          <VideoSettings/>
-        </TabPanel>
-        <TabPanel value={tabIndex} index={3}>
-          <AudioSettings/>
-        </TabPanel>
-        <TabPanel value={tabIndex} index={4}>
-          <AdvancedSettings/>
-        </TabPanel>
-        <div style={{position: "fixed", bottom: "10px", left: "12px"}} >
-          <button type="button" id="close" name="close" className="btn btn-secondary" onClick={closeSettings}>Close</button>
-          <button type="button" id="submit" name="save" className="btn btn-primary" onClick={saveSettings}>Save</button>
-        </div>
-      </Box>
-    </ConfigContext.Provider>
+        <Tab label="General" {...a11yProps(0)} sx = {{ ...categoryTabSx }} />
+        <Tab label="Content" {...a11yProps(1)} sx = {{ ...categoryTabSx }}/>
+        <Tab label="Video" {...a11yProps(2)} sx = {{ ...categoryTabSx }}/>
+        <Tab label="Audio" {...a11yProps(3)} sx = {{ ...categoryTabSx }}/>
+        <Tab label="Advanced" {...a11yProps(4)} sx = {{ ...categoryTabSx }}/>
+      </Tabs>
+      <TabPanel value={tabIndex} index={0}>
+        <GeneralSettings config={config} onChange={modifyConfig}/>
+      </TabPanel>
+      <TabPanel value={tabIndex} index={1}>
+        <ContentSettings config={config} onChange={modifyConfig}/>
+      </TabPanel>
+      <TabPanel value={tabIndex} index={2}>
+        <VideoSettings config={config} onChange={modifyConfig}/>
+      </TabPanel>
+      <TabPanel value={tabIndex} index={3}>
+        <AudioSettings config={config} onChange={modifyConfig}/>
+      </TabPanel>
+      <TabPanel value={tabIndex} index={4}>
+        <AdvancedSettings config={config} onChange={modifyConfig}/>
+      </TabPanel>
+      <div style={{position: "fixed", bottom: "10px", left: "12px"}} >
+        <button type="button" id="close" name="close" className="btn btn-secondary" onClick={closeSettings}>Close</button>
+        <button type="button" id="submit" name="save" className="btn btn-primary" onClick={saveSettings}>Save</button>
+      </div>
+    </Box>
   );
 }

--- a/src/settings/SettingsContext.ts
+++ b/src/settings/SettingsContext.ts
@@ -1,5 +1,0 @@
-import React from "react";
-
-const ConfigContext = React.createContext([{}, () => {}]);
-
-export default ConfigContext;

--- a/src/settings/VideoSettings.tsx
+++ b/src/settings/VideoSettings.tsx
@@ -1,11 +1,9 @@
-import * as React from 'react';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
-import { OurDisplayType } from 'main/types';
-import ConfigContext from "./ConfigContext";
+import { OurDisplayType, ISettingsPanelProps } from 'main/types';
 import { Box, TextField } from '@mui/material';
 import { configSchema } from '../main/configSchema'
 import InfoIcon from '@mui/icons-material/Info';
@@ -23,12 +21,8 @@ const obsCaptureModes = {
   'monitor_capture': 'Monitor Capture'
 };
 
-export default function VideoSettings() {
-  const [config, setConfig] = React.useContext(ConfigContext);
-
-  const modifyConfig = (stateKey: string, value: any) => {
-    setConfig((prevConfig: any) => ({ ...prevConfig, [stateKey]: value }));
-  };
+export default function VideoSettings(props: ISettingsPanelProps) {
+  const { config } = props;
 
   if (!fpsOptions.includes(config.obsFPS)) {
     config.obsFPS = fpsOptions.at(-1);
@@ -102,11 +96,12 @@ export default function VideoSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="obs-capture-mode-label" sx = {style}>Capture Mode</InputLabel>
           <Select
+            name='obsCaptureMode'
             labelId="obs-capture-mode-label"
             id="obs-capture-mode"
             value={config.obsCaptureMode}
             label="Capture Mode"
-            onChange={(event) => modifyConfig('obsCaptureMode', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { Object.entries(obsCaptureModes).map((captureMode: any) =>
@@ -128,11 +123,12 @@ export default function VideoSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="demo-simple-select-label" sx = {style}>Monitor</InputLabel>
           <Select
+            name='monitorIndex'
             labelId="demo-simple-select-label"
             id="monitor-index"
             value={config.monitorIndex}
             label="Monitor"
-            onChange={(event) => modifyConfig('monitorIndex', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { displayConfiguration.map((display: OurDisplayType) =>
@@ -154,11 +150,12 @@ export default function VideoSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="obs-output-resolution-label" sx = {style}>Video Output Resolution</InputLabel>
           <Select
+            name='obsOutputResolution'
             labelId="obs-output-resolution-label"
             id="obs-output-resolution"
             value={config.obsOutputResolution}
             label="Output resolution for OBS"
-            onChange={(event) => modifyConfig('obsOutputResolution', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { outputResolutions.map((res: string) =>
@@ -179,11 +176,12 @@ export default function VideoSettings() {
         <FormControl sx={{my: 1}}>
           <InputLabel id="obs-fps-label" sx = {style}>Video FPS</InputLabel>
           <Select
+            name='obsFPS'
             labelId="obs-fps-label"
             id="obs-fps"
             value={config.obsFPS}
             label="Video FPS"
-            onChange={(event) => modifyConfig('obsFPS', event.target.value)}
+            onChange={props.onChange}
             sx={style}
           >
             { fpsOptions.map((res: string) =>
@@ -202,13 +200,14 @@ export default function VideoSettings() {
 
       <Box component="span" sx={{ display: 'flex', alignItems: 'flex-start' }}>
         <TextField 
+          name='obsKBitRate'
           value={config.obsKBitRate}
-          onChange={event => { modifyConfig("obsKBitRate", parseInt(event.target.value, 10)) }}
+          onChange={props.onChange}
           id="video-bit-rate" 
           label="Video Bit Rate (Mbps)" 
           variant="outlined" 
           type="number" 
-          error= { config.obsKBitRate < 1  || config.obsKBitRate > 300 }
+          error={ config.obsKBitRate < 1  || config.obsKBitRate > 300 }
           helperText={(config.obsKBitRate < 1  || config.obsKBitRate > 300) ? "Must be between 1 and 300" : ' '}
           InputLabelProps={{ shrink: true }}
           sx={{...style, my: 1}}

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -42,7 +42,5 @@ const configValues = {
 };
 
 export default function useSettings() {
-  const [config, setConfig] = React.useState(configValues);
-
-  return [config, setConfig];
+  return React.useState(configValues);
 };


### PR DESCRIPTION
- Give all settings fields a `name` property that matches their state/configuration key since it's included in `event.target.name` which gives us exactly the information we need for the new `modifyConfig()`.

- Add `onChange`, `config` properties to the settings components that provides it with the current configuration as well as a method for changing the config in a central place.

- Remove some extranous whitespace

- Add `FakeChangeEvent` class to mock an event value for when we're saving configuration values delayed from the original change event.

- Remove `ConfigContext`/`SettingsContext`

Adresses parts of #164 