### PR TITLE
282: Play mono microphones through stereo

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.2] - 2022-12-17
 ### Added
 - [Issue 246](https://github.com/aza547/wow-recorder/issues/246) - Config check that storage path and buffer path are different.
+- [Issue 282](https://github.com/aza547/wow-recorder/issues/282) - Added config toggle switch to force input audio to mono.
 
 ### Changed
 - [NO-ISSUE] - Autoplay videos on selection.

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -8,6 +8,7 @@ import {
   EOBSOutputSignal,
   ERecordingFormat,
   ERecordingState,
+  ESourceFlags,
 } from './obsEnums';
 import { deleteVideo, fixPathWhenPackaged, getSortedVideos } from './util';
 import { IOBSDevice, Metadata, RecStatus, TAudioSourceType } from './types';
@@ -493,6 +494,11 @@ export default class Recorder {
     this.audioInputDevices.forEach((device) => {
       const index = this.audioInputDevices.indexOf(device);
       const channel = this.audioInputChannels[index];
+
+      if (this.cfg.get('obsForceMono')) {
+        device.flags = ESourceFlags.ForceMono;
+      }
+
       this.addAudioSourceOBS(device, channel);
     });
 

--- a/src/main/configSchema.ts
+++ b/src/main/configSchema.ts
@@ -13,6 +13,7 @@ export type ConfigurationSchema = {
   startMinimized: boolean;
   obsOutputResolution: string;
   obsFPS: number;
+  obsForceMono: boolean;
   obsKBitRate: number;
   obsCaptureMode: string; // 'game_capture' or 'monitor_capture'
   obsRecEncoder: string;
@@ -108,6 +109,7 @@ export const configSchema = {
     type: 'string',
     default: '1920x1080',
   },
+
   obsFPS: {
     description:
       'The number of frames per second to record the video at. Lower FPS gives smaller video size, but also more choppy playback.',
@@ -115,6 +117,12 @@ export const configSchema = {
     default: 60,
     minimum: 15,
     maximum: 60,
+  },
+  obsForceMono: {
+    description:
+      'Whether to force the audio of your input device to mono. Enable if your microphone audio is only playing out of one stereo channel.',
+    type: 'boolean',
+    default: true,
   },
   obsKBitRate: {
     description:

--- a/src/main/obsEnums.ts
+++ b/src/main/obsEnums.ts
@@ -47,6 +47,13 @@ export const enum EOBSInputTypes {
   CoreAudioOutput = 'coreaudio_output_capture',
 }
 
+export const ESourceFlags = {
+  // eslint-disable-next-line no-bitwise
+  Unbuffered: 1 << 0,
+  // eslint-disable-next-line no-bitwise
+  ForceMono: 1 << 1,
+};
+
 export const enum EOBSFilterTypes {
   FaceMask = 'face_mask_filter',
   Mask = 'mask_filter',

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -2,6 +2,7 @@ import { Size } from 'electron';
 import { ChallengeModeTimelineSegment } from './keystone';
 import Combatant from './Combatant';
 import { VideoCategory } from '../types/VideoCategory';
+import { ConfigurationSchema } from './configSchema';
 
 /**
  * Application recording status.
@@ -166,7 +167,7 @@ interface IOurChangeEvent {
 }
 
 interface ISettingsPanelProps {
-  config: any;
+  config: ConfigurationSchema;
   onChange: (event: IOurChangeEvent) => void;
 }
 

--- a/src/settings/AudioSettings.tsx
+++ b/src/settings/AudioSettings.tsx
@@ -7,10 +7,16 @@ import Box from '@mui/material/Box';
 import InfoIcon from '@mui/icons-material/Info';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
-import { FakeChangeEvent, IOBSDevice, ISettingsPanelProps } from 'main/types';
-import { Checkbox, Chip, ListItemText, OutlinedInput } from '@mui/material';
+import { IOBSDevice, ISettingsPanelProps } from 'main/types';
+import {
+  Checkbox,
+  Chip,
+  FormControlLabel,
+  ListItemText,
+  Switch,
+} from '@mui/material';
 import React from 'react';
-import { configSchema } from '../main/configSchema';
+import { configSchema, ConfigurationSchemaKey } from '../main/configSchema';
 
 const ipc = window.electron.ipcRenderer;
 
@@ -21,55 +27,12 @@ enum DeviceType {
 
 export default function GeneralSettings(props: ISettingsPanelProps) {
   const { config, onChange } = props;
-
-  let initialInputs: string[];
-
-  if (config.audioInputDevices) {
-    initialInputs = String(config.audioInputDevices).split(',');
-  } else {
-    initialInputs = [];
-  }
-
-  let initialOutputs: string[];
-
-  if (config.audioOutputDevices) {
-    initialOutputs = String(config.audioOutputDevices).split(',');
-  } else {
-    initialOutputs = [];
-  }
-
-  const [input, setInput] = React.useState<string[]>(initialInputs);
-  const [output, setOutput] = React.useState<string[]>(initialOutputs);
-
   const devices = ipc.sendSync('getAudioDevices', []);
-
   const inputDevices: IOBSDevice[] = devices.input;
   const outputDevices: IOBSDevice[] = devices.output;
-
   const availableAudioDevices = {
     input: inputDevices,
     output: outputDevices,
-  };
-
-  const handleMultiSelect = (
-    type: DeviceType,
-    event: SelectChangeEvent<string[]>
-  ) => {
-    const {
-      target: { value },
-    } = event;
-
-    if (type === DeviceType.INPUT) {
-      setInput(
-        // On autofill we get a stringified value.
-        typeof value === 'string' ? value.split(',') : value
-      );
-    } else {
-      setOutput(
-        // On autofill we get a stringified value.
-        typeof value === 'string' ? value.split(',') : value
-      );
-    }
   };
 
   const getDeviceDescription = (id: string) => {
@@ -98,21 +61,52 @@ export default function GeneralSettings(props: ISettingsPanelProps) {
     return true;
   };
 
-  // Remove any unknown devices from the list, and the state variables. That
-  // means if the user presses save, even without any changes, the unknown
-  // devices will be removed from config.
-  React.useEffect(() => {
-    const knownInputs = input.filter(isKnownDevice);
-    setInput(knownInputs);
-    onChange(new FakeChangeEvent('audioInputDevices', knownInputs));
+  /**
+   * Standardizes device names to an array of strings and filters by known devices.
+   *
+   * @param deviceNames the device names to standardize
+   * @returns the standardized device names
+   */
+  const standardizeDeviceNames = (deviceNames: string[] | string): string[] => {
+    let normalizedDeviceNames: string[];
 
-    const knownOutputs = output.filter(isKnownDevice);
-    setOutput(knownOutputs);
-    onChange(new FakeChangeEvent('audioOutputDevices', knownOutputs));
-  }, []);
+    if (typeof deviceNames === 'string') {
+      normalizedDeviceNames = deviceNames.split(',');
+    } else {
+      normalizedDeviceNames = deviceNames;
+    }
 
-  const style = {
-    width: '405px',
+    return normalizedDeviceNames.filter(isKnownDevice);
+  };
+
+  const initialInputs = standardizeDeviceNames(config.audioInputDevices);
+  const initialOutputs = standardizeDeviceNames(config.audioOutputDevices);
+  const initialForceMono = config.obsForceMono;
+
+  const [input, setInput] = React.useState<string[]>(initialInputs);
+  const [output, setOutput] = React.useState<string[]>(initialOutputs);
+  const [forceMono, setForceMono] = React.useState<boolean>(initialForceMono);
+
+  const forceMonoConfigKey: ConfigurationSchemaKey = 'obsForceMono';
+
+  const handleMultiSelect = (
+    type: DeviceType,
+    event: SelectChangeEvent<string[]>
+  ) => {
+    const {
+      target: { value },
+    } = event;
+    const standardizedValue: string[] = standardizeDeviceNames(value);
+
+    if (type === DeviceType.INPUT) {
+      setInput(standardizedValue);
+    } else {
+      setOutput(standardizedValue);
+    }
+    onChange(event);
+  };
+
+  const selectStyle = {
     color: 'white',
     '& .MuiOutlinedInput-notchedOutline': {
       borderColor: 'black',
@@ -125,33 +119,47 @@ export default function GeneralSettings(props: ISettingsPanelProps) {
       color: '#bb4220',
     },
   };
+  const formControlStyle = { my: 1, width: '450px' };
+  const switchStyle = {
+    '& .MuiSwitch-switchBase': {
+      '&.Mui-checked': {
+        color: '#fff',
+        '+.MuiSwitch-track': {
+          backgroundColor: '#bb4220',
+          opacity: 1.0,
+        },
+      },
+      '&.Mui-disabled + .MuiSwitch-track': {
+        opacity: 0.5,
+      },
+    },
+  };
 
   return (
     <Stack
       component="form"
       sx={{
-        '& > :not(style)': { m: 0, width: '50ch' },
+        '& > :not(style)': { width: '50ch' },
       }}
       noValidate
       autoComplete="off"
     >
       <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
-        <FormControl sx={{ my: 1 }}>
-          <InputLabel id="demo-simple-select-label" sx={style}>
-            In
+        <FormControl variant="outlined" sx={formControlStyle}>
+          <InputLabel id="input-label" sx={selectStyle}>
+            Input Devices
           </InputLabel>
           <Select
             name="audioInputDevices"
-            labelId="select-audio-in-devices"
+            labelId="input-label"
             id="audio-input-device"
             multiple
             value={input}
-            label="Input"
+            label="Input Devices"
+            sx={selectStyle}
             onChange={(e) => {
               handleMultiSelect(DeviceType.INPUT, e);
-              onChange(e);
             }}
-            input={<OutlinedInput label="Tag" />}
             renderValue={(selected) => {
               return (
                 <Box
@@ -173,7 +181,6 @@ export default function GeneralSettings(props: ISettingsPanelProps) {
                 </Box>
               );
             }}
-            sx={style}
           >
             {availableAudioDevices.input.map((device: IOBSDevice) => {
               // We arbitrarily limit input devices to 3.
@@ -201,22 +208,45 @@ export default function GeneralSettings(props: ISettingsPanelProps) {
         </Tooltip>
       </Box>
       <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
-        <FormControl sx={{ my: 1 }}>
-          <InputLabel id="demo-simple-select-label" sx={style}>
-            Out
+        <FormControlLabel
+          control={
+            <Switch
+              sx={switchStyle}
+              checked={forceMono}
+              name={forceMonoConfigKey}
+              onChange={(isForceMono) => {
+                setForceMono(Boolean(isForceMono.target.checked));
+                onChange(isForceMono);
+              }}
+            />
+          }
+          label="Mono Input"
+          sx={{
+            color: 'white',
+          }}
+        />
+        <Tooltip title={configSchema.obsForceMono.description}>
+          <IconButton>
+            <InfoIcon sx={{ color: 'white' }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
+        <FormControl sx={formControlStyle}>
+          <InputLabel id="ouput-label" sx={selectStyle}>
+            Output Devices
           </InputLabel>
           <Select
             name="audioOutputDevices"
-            labelId="select-audio-devices"
+            labelId="output-label"
             id="audio-output-device"
             multiple
             value={output}
-            label="Output"
+            label="Output Devices"
+            sx={selectStyle}
             onChange={(e) => {
               handleMultiSelect(DeviceType.OUTPUT, e);
-              onChange(e);
             }}
-            input={<OutlinedInput label="Tag" />}
             renderValue={(selected) => (
               <Box
                 sx={{
@@ -236,7 +266,6 @@ export default function GeneralSettings(props: ISettingsPanelProps) {
                 ))}
               </Box>
             )}
-            sx={style}
           >
             {availableAudioDevices.output.map((device: IOBSDevice) => {
               // We arbitrarily limit output devices to 5.

--- a/src/settings/useSettings.ts
+++ b/src/settings/useSettings.ts
@@ -39,6 +39,7 @@ const configValues = {
   recordBattlegrounds: getConfigValue<boolean>('recordBattlegrounds'),
   obsOutputResolution: getConfigValue<string>('obsOutputResolution'),
   obsFPS: getConfigValue<number>('obsFPS'),
+  obsForceMono: getConfigValue<boolean>('obsForceMono'),
   obsKBitRate: getConfigValue<number>('obsKBitRate'),
   obsCaptureMode: getConfigValue<string>('obsCaptureMode'),
   obsRecEncoder: getConfigValue<string>('obsRecEncoder'),


### PR DESCRIPTION
* Add obsForceMono option to configSchema.
* Check obsForceMono in Recorder#addAudioSourcesOBS and sets the appropriate flag on the input device.
* Add switch input to AudioSettings for Force Mono (obsForceMono).
* Slight refactoring of AudioSettings.