### PR TITLE
Bug Fix: Minimum Keystone Settings

### DIFF
--- a/src/main/configSchema.ts
+++ b/src/main/configSchema.ts
@@ -204,7 +204,7 @@ export const configSchema = {
   minKeystoneLevel: {
     description: 'The minimum keystone level to record.',
     type: 'integer',
-    default: 1,
+    default: 2,
   },
   minimizeOnQuit: {
     description: 'Whether the close button should minimize rather than quit.',

--- a/src/settings/AdvancedSettings.tsx
+++ b/src/settings/AdvancedSettings.tsx
@@ -135,7 +135,7 @@ export default function GeneralSettings(props: ISettingsPanelProps) {
           }
           InputLabelProps={{ shrink: true }}
           sx={{ ...style, my: 1 }}
-          inputProps={{ style: { color: 'white' } }}
+          inputProps={{ style: { color: 'white' }, min: 2 }}
         />
         <Tooltip title={configSchema.minKeystoneLevel.description}>
           <IconButton>


### PR DESCRIPTION
The current iteration allows you to press the down arrow to go into the negatives. Even though you can't save, this should prevent that from happening at all. 

Also changed default to 2 as that's where keystones start.