### PR TITLE
Fix styling Dialog popup

### DIFF
--- a/src/renderer/InformationDialog.tsx
+++ b/src/renderer/InformationDialog.tsx
@@ -37,6 +37,7 @@ type ConfirmationDialogProps = {
 const useStyles = makeStyles()({
   dialog: {
     '.MuiDialog-paper': {
+      backgroundColor: '#1a233a',
       maxHeight: '750px',
       maxWidth: '1250px',
       color: 'white',


### PR DESCRIPTION
Fixed background-color for dialog popup avoiding style.

Issue #375

![issue fix](https://user-images.githubusercontent.com/65028567/232290172-6787a1e5-bb56-40a7-a182-51dff613d0e1.PNG)

