### PR TITLE
Added in difficulty IDs for SoD Era for MC / BWL / ZG / Onyxia

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -994,12 +994,14 @@ const instanceDifficulty: InstanceDifficultyObjectType = {
   151: { difficultyID: 'lfr', difficulty: 'T', partyType: 'raid' },
   175: { difficultyID: 'normal', difficulty: '10N', partyType: 'raid' },
   176: { difficultyID: 'normal', difficulty: '25N', partyType: 'raid' },
+  186: { difficultyID: 'normal', difficulty: 'N', partyType: 'raid' },
   193: { difficultyID: 'heroic', difficulty: '10HC', partyType: 'raid' },
   194: { difficultyID: 'heroic', difficulty: '25HC', partyType: 'raid' },
 
   // Classic era 10 man?
   198: { difficultyID: 'normal', difficulty: '10N', partyType: 'raid' },
   215: { difficultyID: 'normal', difficulty: '10N', partyType: 'raid' },
+  226: { difficultyID: 'normal', difficulty: 'N', partyType: 'raid' },
 };
 
 const categoryTabSx = {


### PR DESCRIPTION
Hi, I noticed that MC / BWL / ZG / Onyxia raids are not recorded.

I checked the logs and noticed that these encounters use unknown difficulty IDs for these 10 / 20 man raids.

I labelled both these entries as 'N' because I didn't notice a convention between the raids tuned for 10 or 20 man.

From my log files I observed the following difficulty IDs:
Molten Core - 226
Blackwing Lair - 186
Zul'Gurub - 226
Onyxia - 186

Please let me know if I can provide any more information to help resolve this. I've attached a recent logfile below that should contain all these raids. The ENCOUNTER_START is detected correctly but the new difficulty ID raises an exception. 

[WarcraftRecorder-2024-10-12.log](https://github.com/user-attachments/files/17447166/WarcraftRecorder-2024-10-12.log)
