### PR TITLE
Fix CMAA 2 game capture

### DIFF
--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -1193,7 +1193,7 @@ export default class Recorder extends EventEmitter {
 
     const { settings } = this.gameCaptureSource;
     settings.capture_mode = 'window';
-    settings.allow_transparency = true;
+    settings.allow_transparency = false;
     settings.priority = 1;
     settings.capture_cursor = captureCursor;
     settings.window = window;


### PR DESCRIPTION
Disables `allow_transparency` on the Game Capture source. I'm not aware of any uses for this feature when capturing gameplay and it really borks capture when CMAA 2 is enabled in WoW.
If it is needed for something then it should probably be exposed to the user somewhere (but that's outside the scope of this 1-line hack).