### PR TITLE
Added in difficulty IDs for Ruins of AQ SoD P6

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -994,6 +994,7 @@ const instanceDifficulty: InstanceDifficultyObjectType = {
   151: { difficultyID: 'lfr', difficulty: 'T', partyType: 'raid' },
   175: { difficultyID: 'normal', difficulty: '10N', partyType: 'raid' },
   176: { difficultyID: 'normal', difficulty: '25N', partyType: 'raid' },
+  185: { difficultyID: 'normal', difficulty: 'N', partyType: 'raid' },
   186: { difficultyID: 'normal', difficulty: 'N', partyType: 'raid' },
   193: { difficultyID: 'heroic', difficulty: '10HC', partyType: 'raid' },
   194: { difficultyID: 'heroic', difficulty: '25HC', partyType: 'raid' },


### PR DESCRIPTION
Added the new difficulty ID (185) for Ruins of AQ

Temple of AQ / Nightmare reuse old difficulty IDs and work correctly.