### PR TITLE
Enable AV1 nvidia hardware encoding support

### DIFF
--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "WarcraftRecorder",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "WarcraftRecorder",
-      "version": "6.8.1",
+      "version": "6.8.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -516,6 +516,7 @@ export default class Recorder extends EventEmitter {
 
       case ESupportedEncoders.AMD_AMF_H264:
       case ESupportedEncoders.JIM_NVENC:
+      case ESupportedEncoders.JIM_AV1_NVENC:
         // These settings are identical for AMD and NVENC encoders.
         Recorder.applySetting('Output', 'Recrate_control', 'CQP');
         Recorder.applySetting('Output', 'Reccqp', cqp);

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -504,7 +504,7 @@ export default class Recorder extends EventEmitter {
     // vice versa. The limits on what this can actually be set to I took
     // from what OBS studio allows and is annotated below, but we don't
     // go to the extremes of the allowed range anyway.
-    const cqp = Recorder.getCqpFromQuality(obsQuality);
+    const cqp = Recorder.getCqpFromQuality(obsQuality, obsRecEncoder);
 
     switch (obsRecEncoder) {
       case ESupportedEncoders.OBS_X264:
@@ -1489,22 +1489,36 @@ export default class Recorder extends EventEmitter {
   }
 
   /**
-   * Convert the quality setting to an appropriate CQP value.
+   * Convert the quality setting to an appropriate CQP/CRF value based on encoder type.
    */
-  private static getCqpFromQuality(obsQuality: string) {
+  private static getCqpFromQuality(obsQuality: string, encoder: string) {
+    if (encoder === ESupportedEncoders.JIM_AV1_NVENC) {
+      // AV1 NVENC typically needs lower CQP values for similar quality
+      switch (obsQuality) {
+        case QualityPresets.ULTRA:
+          return 20;
+        case QualityPresets.HIGH:
+          return 24;
+        case QualityPresets.MODERATE:
+          return 28;
+        case QualityPresets.LOW:
+          return 32;
+        default:
+          console.error('[Recorder] Unrecognised quality', obsQuality);
+          throw new Error('Unrecognised quality');
+      }
+    }
+
+    // Original values for x264 CRF and other encoders' CQP
     switch (obsQuality) {
       case QualityPresets.ULTRA:
         return 22;
-
       case QualityPresets.HIGH:
         return 26;
-
       case QualityPresets.MODERATE:
         return 30;
-
       case QualityPresets.LOW:
         return 34;
-
       default:
         console.error('[Recorder] Unrecognised quality', obsQuality);
         throw new Error('Unrecognised quality');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -42,10 +42,6 @@ let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 let manager: Manager | undefined;
 
-// Issue 332. Need to call this before the app is ready.
-// https://www.electronjs.org/docs/latest/api/app#appdisablehardwareacceleration
-app.disableHardwareAcceleration();
-
 /**
  * Create a settings store to handle the config.
  * This defaults to a path like:

--- a/src/main/obsEnums.ts
+++ b/src/main/obsEnums.ts
@@ -113,6 +113,7 @@ export enum ESupportedEncoders {
   AMD_AMF_H264 = 'h264_texture_amf',
   JIM_NVENC = 'jim_nvenc',
   OBS_X264 = 'obs_x264',
+  JIM_AV1_NVENC = 'jim_av1_nvenc',
 }
 
 export enum QualityPresets {

--- a/src/renderer/rendererutils.ts
+++ b/src/renderer/rendererutils.ts
@@ -653,9 +653,9 @@ const encoderFilter = (enc: string, highRes: boolean) => {
     return false;
   }
 
-  // If we have a resolution above 4k, only the software encoder is valid.
+  // If we have a resolution above 4k, only the software and AV1 hardware encoders are valid.
   if (highRes) {
-    return encoder === ESupportedEncoders.OBS_X264;
+    return encoder === ESupportedEncoders.OBS_X264 || encoder === ESupportedEncoders.JIM_AV1_NVENC;
   }
 
   return true;


### PR DESCRIPTION
This PR enables AV1 encoding support using nvidia hardware encoder in series 4000 and later GPUs with custom CRF values (based on personal testing mostly).
On supported cards, benefits include:
- much smaller file size
- up to 8k60 resolution support (including the dreaded 5120x1440)
This also enables hardware rendering in the app. In my testing it works without it, but with high-resolution playback, it's using up to 35% of my CPU (ryzen 7 9800x3d), so I would strongly recommend it.