### PR TITLE
Update constants.ts

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -166,6 +166,7 @@ const retailArenas: NumberKeyToStringValueMapType = {
   2509: 'Maldraxxus',
   2547: 'Enigma Crucible',
   2563: 'Nokhudon',
+  2759: 'Cage of Carnage',
 };
 
 /**


### PR DESCRIPTION

![areana1](https://github.com/user-attachments/assets/c43a7e91-5b07-4898-8e21-1541b9465965)


`2759: 'Cage of Carnage',`

I think the 11.1.0 new arena area is missing.