### PR TITLE
feat: add button to reset video to its original height

### DIFF
--- a/src/localisation/chineseSimplified.ts
+++ b/src/localisation/chineseSimplified.ts
@@ -357,6 +357,7 @@ const CHINESE_SIMPLIFIED: Translations = {
   [Phrase.Saving]: '保存',
   [Phrase.StartTyping]: '开始打字',
   [Phrase.ToggleDrawingMode]: '切换绘图模式',
+  [Phrase.ResetVideoHeight]: '重置视频高度',
   [Phrase.StarSelected]: '锁定选定的行',
   [Phrase.UnstarSelected]: '解锁选定的行',
   [Phrase.Selection]: '选择',

--- a/src/localisation/english.ts
+++ b/src/localisation/english.ts
@@ -357,6 +357,7 @@ const ENGLISH: Translations = {
   [Phrase.Saving]: 'Saving...',
   [Phrase.StartTyping]: 'Start typing...',
   [Phrase.ToggleDrawingMode]: 'Toggle drawing mode',
+  [Phrase.ResetVideoHeight]: 'Reset video height',
   [Phrase.StarSelected]: 'Lock selected rows. Locked rows will not be automatically aged out.',
   [Phrase.UnstarSelected]: 'Unlock selected rows. Unlocked rows may be automatically aged out to make space for new recordings.',
   [Phrase.Selection]: 'Selection',

--- a/src/localisation/german.ts
+++ b/src/localisation/german.ts
@@ -357,6 +357,7 @@ const GERMAN: Translations = {
   [Phrase.Saving]: 'Sparen...',
   [Phrase.StartTyping]: 'Beginnen Sie mit der Eingabe...',
   [Phrase.ToggleDrawingMode]: 'Zeichenmodus umschalten',
+  [Phrase.ResetVideoHeight]: 'Videohöhe zurücksetzen',
   [Phrase.StarSelected]: 'Ausgewählte Zeilen sperren.',
   [Phrase.UnstarSelected]: 'Ausgewählte Zeilen entsperren.',
   [Phrase.Selection]: 'Auswahl',

--- a/src/localisation/korean.ts
+++ b/src/localisation/korean.ts
@@ -357,6 +357,7 @@ const KOREAN: Translations = {
   [Phrase.Saving]: '저장...',
   [Phrase.StartTyping]: '검색...',
   [Phrase.ToggleDrawingMode]: '그리기 모드 전환',
+  [Phrase.ResetVideoHeight]: '동영상 높이 초기화',
   [Phrase.StarSelected]: '선택한 행 잠금',
   [Phrase.UnstarSelected]: '선택한 행 잠금 해제',
   [Phrase.Selection]: '선택',

--- a/src/localisation/types.ts
+++ b/src/localisation/types.ts
@@ -354,6 +354,7 @@ enum Phrase {
   Saving,
   StartTyping,
   ToggleDrawingMode,
+  ResetVideoHeight,
   UnstarSelected,
   StarSelected,
   Selection,

--- a/src/renderer/CategoryPage.tsx
+++ b/src/renderer/CategoryPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppState, RendererVideo } from 'main/types';
-import { MutableRefObject, useMemo } from 'react';
+import { MutableRefObject, useMemo, useState } from 'react';
 import {
   Eye,
   GripHorizontal,
@@ -74,6 +74,9 @@ const CategoryPage = (props: IProps) => {
   const { write, del } = cloudStatus;
 
   const [config, setConfig] = useSettings();
+  const [resizableHeight, setResizableHeight] = useState(
+    `${playerHeight?.current || 300}px`, // Fallback to 300px if playerHeight.current is undefined
+  );
 
   const filteredState = useMemo<RendererVideo[]>(() => {
     const queryFilter = (rv: RendererVideo) =>
@@ -97,9 +100,12 @@ const CategoryPage = (props: IProps) => {
     element: HTMLElement,
   ) => {
     const height = element.clientHeight;
-    playerHeight.current = height;
+    setResizableHeight(`${height}px`);
   };
 
+  const onResetHeight = (newHeight: number) => {
+    setResizableHeight(`${newHeight}px`);
+  };
   /**
    * Render the video player. Safe to assume we have videos at this point
    * as we don't call this if haveVideos isn't true.
@@ -110,14 +116,16 @@ const CategoryPage = (props: IProps) => {
   const getVideoPlayer = () => {
     const toShow = filteredState[0] ? filteredState[0] : categoryState[0];
     const povs = [toShow, ...toShow.multiPov].sort(povDiskFirstNameSort);
-
     const videosToPlay =
       selectedVideos.length > 0 ? selectedVideos : povs.slice(0, 1);
-
     return (
       <Resizable
+        size={{
+          height: resizableHeight,
+          width: '100%',
+        }}
         defaultSize={{
-          height: `${playerHeight.current}px`,
+          height: resizableHeight,
           width: '100%',
         }}
         enable={{ bottom: true }}
@@ -146,6 +154,7 @@ const CategoryPage = (props: IProps) => {
           config={config}
           appState={appState}
           setAppState={setAppState}
+          onResetHeight={onResetHeight}
         />
       </Resizable>
     );

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -58,6 +58,7 @@ import SaveIcon from '@mui/icons-material/Save';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
 import Separator from './components/Separator/Separator';
 import { toast } from './components/Toast/useToast';
+import AspectRatioIcon from '@mui/icons-material/AspectRatio';
 
 interface IProps {
   videos: RendererVideo[];
@@ -66,6 +67,7 @@ interface IProps {
   config: ConfigurationSchema;
   appState: AppState;
   setAppState: React.Dispatch<React.SetStateAction<AppState>>;
+  onResetHeight?: (newHeight: number) => void;
 }
 
 const ipc = window.electron.ipcRenderer;
@@ -104,6 +106,7 @@ export const VideoPlayer = (props: IProps) => {
     appState,
     setAppState,
     categoryState,
+    onResetHeight,
   } = props;
 
   const { playing, multiPlayerMode, language, selectedVideos } = appState;
@@ -1146,6 +1149,33 @@ export const VideoPlayer = (props: IProps) => {
     </Tooltip>
   );
 
+  const resetHeightHandler = () => {
+    if (!onResetHeight) {
+      return;
+    }
+    const primaryPlayer = players[0].current;
+    if (!primaryPlayer) {
+      return;
+    }
+    const internalPlayer =
+      primaryPlayer.getInternalPlayer() as HTMLVideoElement;
+    const originalHeight = internalPlayer?.videoHeight;
+    if (originalHeight) {
+      //if the original height is greater than the window height, set it to window height - 60 (the bar height)
+      onResetHeight(Math.min(originalHeight, window.innerHeight - 60));
+    }
+  };
+
+  const renderResize = () => {
+    return (
+      <Tooltip content={getLocalePhrase(language, Phrase.ResetVideoHeight)}>
+        <Button variant="ghost" size="xs" onClick={resetHeightHandler}>
+          <AspectRatioIcon sx={{ color: 'white', fontSize: '22px' }} />
+        </Button>
+      </Tooltip>
+    );
+  };
+
   /**
    * Returns the entire video control component.
    */
@@ -1172,6 +1202,7 @@ export const VideoPlayer = (props: IProps) => {
           <Separator className="mx-2" orientation="vertical" />
         )}
         {!clipMode && renderPlaybackRateButton()}
+        {!clipMode && renderResize()}
         {!clipMode && renderFullscreenButton()}
         {clipMode && renderClipFinishedButton()}
         {clipMode && renderClipCancelButton()}


### PR DESCRIPTION
This PR introduces a new feature that allows users to reset the video player's height to its original value with a single click. The key components of this update include:

UI Integration: A new button is added to the video player's control panel. This button leverages a Material-Icons design to indicate a "reset" action visually.

Functionality: Clicking the button calls a handler that retrieves the video player's original height (or uses a safe fallback) and adjusts the display accordingly. This ensures users can quickly revert any height adjustments without manually resizing the player.

Localization Updates: The feature is fully localized by updating the translation files in English, Chinese, Korean, and German. This ensures that the button's tooltip or accessible label (e.g., "Reset video height" in English) is displayed appropriately based on the user's locale.

Code Modifications: Changes have been made to both CategoryPage.tsx and VideoPlayer.tsx to incorporate the new reset logic and integrate the UI element seamlessly into the current video controls.

This enhancement improves the overall user experience by providing a quick and intuitive way to restore the video to its intended dimensions. Feedback and suggestions are very welcome.