### PR TITLE
Add a region from combat log to the saved metadata.

### DIFF
--- a/src/main/Combatant.ts
+++ b/src/main/Combatant.ts
@@ -14,6 +14,8 @@ export default class Combatant {
 
   private _realm?: string;
 
+  private _region?: string;
+
   /**
    * Constructs a new Combatant.
    *
@@ -107,13 +109,30 @@ export default class Combatant {
     this._realm = value;
   }
 
+  /**
+   * Gets the region.
+   */
+  get region() {
+    return this._region;
+  }
+
+  /**
+   * Sets the region.
+   */
+  set region(value) {
+    this._region = value;
+  }
+
   isFullyDefined() {
     const hasGUID = this.teamID !== undefined;
     const hasName = this.name !== undefined;
     const hasRealm = this.realm !== undefined;
+    const hasRegion = this.region !== undefined;
     const hasSpecID = this.specID !== undefined;
     const hasTeamID = this.teamID !== undefined;
-    return hasGUID && hasName && hasRealm && hasSpecID && hasTeamID;
+    return (
+      hasGUID && hasName && hasRealm && hasRegion && hasSpecID && hasTeamID
+    );
   }
 
   getRaw(): RawCombatant {
@@ -123,6 +142,7 @@ export default class Combatant {
     if (this.specID !== undefined) rawCombatant._specID = this.specID;
     if (this.name !== undefined) rawCombatant._name = this.name;
     if (this.realm !== undefined) rawCombatant._realm = this.realm;
+    if (this.region !== undefined) rawCombatant._region = this.region;
 
     return rawCombatant;
   }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -242,6 +242,7 @@ type RawCombatant = {
   _specID?: number;
   _name?: string;
   _realm?: string;
+  _region?: string;
 };
 
 /**

--- a/src/parsing/LogHandler.ts
+++ b/src/parsing/LogHandler.ts
@@ -427,7 +427,8 @@ export default abstract class LogHandler extends EventEmitter {
       return combatant;
     }
 
-    [combatant.name, combatant.realm] = ambiguate(srcNameRealm);
+    [combatant.name, combatant.realm, combatant.region] =
+      ambiguate(srcNameRealm);
     this.activity.addCombatant(combatant);
     return combatant;
   }

--- a/src/parsing/logutils.ts
+++ b/src/parsing/logutils.ts
@@ -24,5 +24,6 @@ export const ambiguate = (nameRealm: string): string[] => {
   const split = nameRealm.split('-');
   const name = split[0];
   const realm = split[1];
-  return [name, realm];
+  const region = split[3];
+  return [name, realm, region];
 };


### PR DESCRIPTION
This PR extends combatant metadata by extracting a region from the combat log and persisting it through the parsing pipeline.

- Augments `ambiguate` to return a third element for region
- Updates `LogHandler` and `types` to include `_region`
- Extends `Combatant` class with a `region` property, adjusts `isFullyDefined` and serialization

### Reviewed Changes

| File                       | Description                                    |
| -------------------------- | ---------------------------------------------- |
| src/parsing/logutils.ts    | Extracts `region` from the split and returns it|
| src/parsing/LogHandler.ts  | Destructures and assigns `combatant.region`     |
| src/main/types.ts          | Adds `_region` field to `RawCombatant`         |
| src/main/Combatant.ts      | Adds `region` getter/setter, updates checks and serialization |

