### PR TITLE
Add Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ buffer
 
 # Some stuff OBS window capture creates at runtime?
 win-capture/
+
+# Native addon binary
+noobs.node

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tsc": "^2.0.4",
         "tss-react": "^4.1.1",
+        "uiohook-napi": "^1.5.4",
         "uuid": "^11.0.3",
         "wait-queue": "^1.1.4",
         "ws": "^8.18.2",
@@ -18662,6 +18663,17 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-gyp/node_modules/@npmcli/fs": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
@@ -24989,6 +25001,19 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/uiohook-napi": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.5.4.tgz",
+      "integrity": "sha512-7vPVDNwgb6MwTgviA/dnF2MrW0X5xm76fAqaOAC3cEKkswqAZOPw1USu14Sr6383s5qhXegcJaR63CpJOPCNAg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "4.x.x"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,16 @@
         "nsis"
       ]
     },
+    "linux": {
+      "artifactName": "WarcraftRecorder-${version}-${arch}.${ext}",
+      "target": [
+        "AppImage",
+        "deb",
+        "rpm"
+      ],
+      "category": "Game;Utility",
+      "maintainer": "Warcraft Recorder"
+    },
     "directories": {
       "app": "release/app",
       "buildResources": "assets",
@@ -170,6 +180,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tsc": "^2.0.4",
     "tss-react": "^4.1.1",
+    "uiohook-napi": "^1.5.4",
     "uuid": "^11.0.3",
     "wait-queue": "^1.1.4",
     "ws": "^8.18.2",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "WarcraftRecorder",
   "version": "7.3.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -13,8 +13,25 @@
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.1.2",
         "atomic-queue": "^5.0.4",
-        "noobs": "^0.0.181",
+        "noobs": "file:../../../noobs-linux",
         "uiohook-napi": "^1.5.2"
+      }
+    },
+    "../../../noobs-linux": {
+      "name": "noobs",
+      "version": "0.0.181",
+      "hasInstallScript": true,
+      "license": "LGPL-2.0",
+      "dependencies": {
+        "node-addon-api": "^8.4.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.1.0",
+        "node-gyp": "^11.2.0",
+        "ts-node": "^10.9.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@ffmpeg-installer/darwin-arm64": {
@@ -274,6 +291,9 @@
     },
     "node_modules/abstract-leveldown": {
       "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -281,6 +301,8 @@
     },
     "node_modules/acorn": {
       "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -291,6 +313,8 @@
     },
     "node_modules/atomic-queue": {
       "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/atomic-queue/-/atomic-queue-5.0.4.tgz",
+      "integrity": "sha512-hCqC5cH7twfphr4HWHMEap08idWJ4Kearrs1CzuyuuwjkWE32a1nIjyZa0if37+b77x/Tvp0QcNQ2P/rr6ancQ==",
       "license": "BSD",
       "dependencies": {
         "changes-feed": "^1.1.0",
@@ -307,6 +331,8 @@
     },
     "node_modules/bl": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+      "integrity": "sha512-pfqikmByp+lifZCS0p6j6KreV6kNU6Apzpm2nKOk+94cZb/jvle55+JxWiByUQ0Wo/+XnDXEy5MxxKMb6r0VIw==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~1.0.26"
@@ -314,10 +340,14 @@
     },
     "node_modules/bl/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/bl/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -328,10 +358,14 @@
     },
     "node_modules/bl/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/brfs": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+      "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
       "license": "MIT",
       "dependencies": {
         "quote-stream": "^1.0.1",
@@ -345,6 +379,8 @@
     },
     "node_modules/brfs/node_modules/through2": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -353,6 +389,8 @@
     },
     "node_modules/buffer-equal": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -360,10 +398,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
     "node_modules/changes-feed": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/changes-feed/-/changes-feed-1.1.0.tgz",
+      "integrity": "sha512-R2mk2aL6bm0DgBIqgkWDPiTIrNdzGr9bB2dqPSDWW+FxG2C+g40APzpU0Zj7wqKTcznxuv+rh9Ju4KfP+/Lddg==",
       "license": "MIT",
       "dependencies": {
         "from2": "^1.3.0",
@@ -376,6 +418,8 @@
     },
     "node_modules/changesdown": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/changesdown/-/changesdown-2.3.1.tgz",
+      "integrity": "sha512-JmV3CyZq8iGpR5yVozOVz9DnAEULF/NLl0WbsFwlU4KM2VfW+FOv+FSiYuq3PY6A5mKCEKeRhcYLv6wofjmucA==",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^2.1.0",
@@ -389,6 +433,9 @@
     },
     "node_modules/changesdown/node_modules/subleveldown": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-1.1.0.tgz",
+      "integrity": "sha512-9Ov0qeR2ew/EbNIfGGkHcM7PcHvE5TW3C+g22eCqO5vgHoUmCA/H9nlHopbZUEJZVn+Y2u6ZcrGswKT1sN5TVA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^2.1.0",
@@ -398,6 +445,8 @@
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -411,14 +460,20 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -426,10 +481,15 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "license": "MIT"
     },
     "node_modules/deferred-leveldown": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+      "integrity": "sha512-+WCbb4+ez/SZ77Sdy1iadagFiVzMB89IKOBhglgnUkVxOxRWmmFsz8UDSNWh4Rhq+3wr/vMFlYj+rdEwWUDdng==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~0.12.1"
@@ -437,6 +497,9 @@
     },
     "node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
       "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+      "integrity": "sha512-TOod9d5RDExo6STLMGa+04HGkl+TlMfbDnTyN93/ETJ9DpQ0DaYLqcMZlbXvdc4W3vVo1Qrl+WhSp8zvDsJ+jA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "xtend": "~3.0.0"
@@ -444,16 +507,22 @@
     },
     "node_modules/deferred-leveldown/node_modules/xtend": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/defined": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
       "license": "MIT"
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "readable-stream": "^2.0.2"
@@ -461,6 +530,8 @@
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.0.0",
@@ -470,7 +541,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -478,6 +551,8 @@
     },
     "node_modules/errno": {
       "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "license": "MIT",
       "dependencies": {
         "prr": "~1.0.1"
@@ -488,10 +563,14 @@
     },
     "node_modules/errno/node_modules/prr": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "license": "MIT"
     },
     "node_modules/escodegen": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^3.1.3",
@@ -512,6 +591,8 @@
     },
     "node_modules/esprima": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha512-AWwVMNxwhN8+NIPQzAQZCm7RkLC4RbM3B1OobMuyp3i+w73X57KCKaVIxaRZb+DYCojq7rspo+fmuQfAboyhFg==",
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -523,6 +604,8 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -530,6 +613,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -537,6 +622,8 @@
     },
     "node_modules/falafel": {
       "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+      "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^7.1.1",
@@ -548,14 +635,20 @@
     },
     "node_modules/falafel/node_modules/isarray": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
     },
     "node_modules/from2": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+      "integrity": "sha512-1eKYoECvhpM4IT70THQV8XNfmZoIlnROymbwOSazfmQO3kK+zCV+LSqUDzl7gDo3MZddCFeVa9Zg3Hi6FXqcgg==",
       "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.1",
@@ -564,10 +657,14 @@
     },
     "node_modules/from2/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/from2/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -578,14 +675,23 @@
     },
     "node_modules/from2/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "license": "MIT"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/generate-function": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
@@ -593,34 +699,59 @@
     },
     "node_modules/generate-object-property": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.0"
       }
     },
     "node_modules/has": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
       "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
       "engines": {
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hat": {
       "version": "0.0.3",
-      "license": "MIT/X11"
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "integrity": "sha512-zpImx2GoKXy42fVDSEad2BPKuSQdLcqsCYa48K3zHSzM/ugWuYjLDr8IXxpVuL7uCLHw56eaiLxCRthhOzf5ug==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -628,18 +759,28 @@
     },
     "node_modules/is-property": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/level-codec": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
+      "deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
       "license": "MIT"
     },
     "node_modules/level-errors": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "errno": "~0.1.1"
@@ -647,6 +788,8 @@
     },
     "node_modules/level-iterator-stream": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "integrity": "sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
@@ -657,10 +800,14 @@
     },
     "node_modules/level-iterator-stream/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/level-iterator-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -671,10 +818,14 @@
     },
     "node_modules/level-iterator-stream/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/level-option-wrap": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
+      "integrity": "sha512-gQouC22iCqHuBLNl4BHxEZUxLvUKALAtT/Q0c6ziOxZQ8c02G/gyxHWNbLbxUzRNfMrRnbt6TZT3gNe8VBqQeg==",
       "license": "MIT",
       "dependencies": {
         "defined": "~0.0.0"
@@ -682,6 +833,9 @@
     },
     "node_modules/levelup": {
       "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+      "integrity": "sha512-FljDvNf24vbG8fiO1iF0XbLym1lrR80wmn+x6NOFxhJ9arbPWXkzfhJpS8a2w5ft8MaD95c0+RvEHa0QHegAUA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "bl": "~0.8.1",
@@ -695,10 +849,14 @@
     },
     "node_modules/levelup/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/levelup/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -709,16 +867,22 @@
     },
     "node_modules/levelup/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/levelup/node_modules/xtend": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/levn": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -730,10 +894,14 @@
     },
     "node_modules/lexicographic-integer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lexicographic-integer/-/lexicographic-integer-1.1.0.tgz",
+      "integrity": "sha512-MQCrf1gG31DJSNQDiIfgk7CQVlXkO6xC+DFGExs5WQWlxWSSAroH5k/UrKrS6LThHDHBoc3X1pNoYHDKOCPWRQ==",
       "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "license": "MIT",
       "dependencies": {
         "vlq": "^0.2.2"
@@ -741,6 +909,8 @@
     },
     "node_modules/memdb": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memdb/-/memdb-0.2.0.tgz",
+      "integrity": "sha512-Ya7CwL5SU2AtplhoScZ0wjAq8GsmESerzjIzRI4CcxfVij115O1LcsM6cY7c4zSS1cysh63uLtji7g407M5OcQ==",
       "license": "MIT",
       "dependencies": {
         "levelup": "~0.18.3",
@@ -749,10 +919,15 @@
     },
     "node_modules/memdb/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/memdb/node_modules/levelup": {
       "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.18.6.tgz",
+      "integrity": "sha512-uB0auyRqIVXx+hrpIUtol4VAPhLRcnxcOsd2i2m6rbFIDarO5dnrupLOStYYpEcu8ZT087Z9HEuYw1wjr6RL6Q==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "bl": "~0.8.1",
@@ -766,6 +941,8 @@
     },
     "node_modules/memdb/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -776,6 +953,8 @@
     },
     "node_modules/memdb/node_modules/semver": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+      "integrity": "sha512-abLdIKCosKfpnmhS52NCTjO4RiLspDfsn37prjzGrp9im5DPJOgh82Os92vtwGh6XdQryKI/7SREZnV+aqiXrA==",
       "license": "BSD",
       "bin": {
         "semver": "bin/semver"
@@ -783,16 +962,23 @@
     },
     "node_modules/memdb/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/memdb/node_modules/xtend": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/memdown": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-0.8.0.tgz",
+      "integrity": "sha512-hBRyVdgw8YlH/zvh3weBER1cdiM9iPOgd8B5tR+T52kg9vlzBNK7ngSG7tRWuyK4llNP2Mn5JJdBgqbdnMlHmg==",
+      "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~0.12.0"
@@ -800,6 +986,9 @@
     },
     "node_modules/memdown/node_modules/abstract-leveldown": {
       "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+      "integrity": "sha512-TOod9d5RDExo6STLMGa+04HGkl+TlMfbDnTyN93/ETJ9DpQ0DaYLqcMZlbXvdc4W3vVo1Qrl+WhSp8zvDsJ+jA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "xtend": "~3.0.0"
@@ -807,12 +996,16 @@
     },
     "node_modules/memdown/node_modules/xtend": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+      "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg==",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/merge-source-map": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha512-PGSmS0kfnTnMJCzJ16BLLCEe6oeYCamKFFdQKshi4BmM6FUwipjVOcBFGxqtQtirtAG4iZvHlqST9CpZKqlRjA==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.5.6"
@@ -820,13 +1013,17 @@
     },
     "node_modules/merge-source-map/node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -834,26 +1031,23 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/mutexify": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mutexify/-/mutexify-1.4.0.tgz",
+      "integrity": "sha512-pbYSsOrSB/AKN5h/WzzLRMFgZhClWccf2XIB4RSMC8JbquiB0e0/SH5AIfdQMdyHmYtv4seU7yV/TvAwPLJ1Yg==",
       "license": "MIT",
       "dependencies": {
         "queue-tick": "^1.0.0"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/node-gyp-build": {
-      "version": "4.6.1",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -862,24 +1056,19 @@
       }
     },
     "node_modules/noobs": {
-      "version": "0.0.181",
-      "resolved": "https://registry.npmjs.org/noobs/-/noobs-0.0.181.tgz",
-      "integrity": "sha512-wQuDX910TiW02msJoPfLt4y6d84bZhQUZdt2+zglrY60lDlcXJIXZV2twX368AFIaPXEXZME5p0HgNxIvyjwRw==",
-      "hasInstallScript": true,
-      "license": "LGPL-2.0",
-      "dependencies": {
-        "node-addon-api": "^8.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "resolved": "../../../noobs-linux",
+      "link": true
     },
     "node_modules/object-inspect": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+      "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw==",
       "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -887,6 +1076,8 @@
     },
     "node_modules/optionator": {
       "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "license": "MIT",
       "dependencies": {
         "deep-is": "~0.1.3",
@@ -902,24 +1093,34 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/protobuf-schema": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/protobuf-schema/-/protobuf-schema-1.5.1.tgz",
+      "integrity": "sha512-jPi6WrJQeqr717Fd42bY9L+rKb6VwGA3ZMAe9X3hwaIrCqW+bM+K+wu+DlVnP5MY2QoS6mqNIiOf9elymWdT6A==",
       "license": "MIT"
     },
     "node_modules/protocol-buffers": {
       "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers/-/protocol-buffers-2.7.0.tgz",
+      "integrity": "sha512-uaQMT6i8KHUFA/vrSGb97tGXzgoWYxnf/Ledpx7x6vQPjbxRp4muN8DRz0PMi/IuNjB8Uq79h3Y24MFS+jYz3Q==",
       "license": "MIT",
       "dependencies": {
         "generate-function": "^2.0.0",
@@ -932,10 +1133,14 @@
     },
     "node_modules/prr": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha512-LmUECmrW7RVj6mDWKjTXfKug7TFGdiz9P18HMcO4RHL+RW7MCOGNvpj5j47Rnp6ne6r4fZ2VzyUWEpKbg+tsjQ==",
       "license": "MIT"
     },
     "node_modules/pump": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -944,6 +1149,8 @@
     },
     "node_modules/pumpify": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "license": "MIT",
       "dependencies": {
         "duplexify": "^3.6.0",
@@ -953,6 +1160,8 @@
     },
     "node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -961,10 +1170,14 @@
     },
     "node_modules/queue-tick": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
       "license": "MIT"
     },
     "node_modules/quote-stream": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+      "integrity": "sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==",
       "license": "MIT",
       "dependencies": {
         "buffer-equal": "0.0.1",
@@ -977,6 +1190,8 @@
     },
     "node_modules/quote-stream/node_modules/through2": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -984,7 +1199,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -997,15 +1214,20 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1013,6 +1235,8 @@
     },
     "node_modules/resolve-protobuf-schema": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-1.0.2.tgz",
+      "integrity": "sha512-x9optLjaRApo9b/CKahouGGpkUYbsBfEp3TpmwQCZUcu4t7c6hTXPWVwpDdy4Y4e5wKtg/G15rp1btIAQG2waA==",
       "license": "MIT",
       "dependencies": {
         "protobuf-schema": "^1.2.0"
@@ -1020,10 +1244,14 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+      "integrity": "sha512-bNx9Zdbi1OUN62PbKeG4IgGG8YILX/nkHJ0NQEBwg5FmX8qTJfqhYd3reqkm0DxHCC8nkazb6UjNiBSHCBWVtA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -1031,10 +1259,14 @@
     },
     "node_modules/shallow-copy": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw==",
       "license": "MIT"
     },
     "node_modules/signed-varint": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
       "license": "MIT",
       "dependencies": {
         "varint": "~5.0.0"
@@ -1042,10 +1274,14 @@
     },
     "node_modules/signed-varint/node_modules/varint": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
       "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -1053,27 +1289,30 @@
       }
     },
     "node_modules/static-eval": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
+      "integrity": "sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==",
       "license": "MIT",
       "dependencies": {
-        "escodegen": "^1.11.1"
+        "escodegen": "^2.1.0"
       }
     },
     "node_modules/static-eval/node_modules/escodegen": {
-      "version": "1.14.3",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
         "esgenerate": "bin/esgenerate.js"
       },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=6.0"
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
@@ -1081,6 +1320,8 @@
     },
     "node_modules/static-eval/node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -1090,8 +1331,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/static-eval/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/static-module": {
       "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+      "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
       "license": "MIT",
       "dependencies": {
         "concat-stream": "~1.6.0",
@@ -1112,6 +1364,8 @@
     },
     "node_modules/static-module/node_modules/through2": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "~2.3.6",
@@ -1120,17 +1374,23 @@
     },
     "node_modules/stream-collector": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
+      "integrity": "sha512-b9/C+HonJNmPmdBFGa0aJc9cai07YksAFvmchnSobiIitppiBn6wfAN7rLGEz6fE30Rj9EC/UVkovzoLJTpC5Q==",
       "license": "MIT",
       "dependencies": {
         "once": "^1.3.1"
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -1138,6 +1398,9 @@
     },
     "node_modules/subleveldown": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-2.1.0.tgz",
+      "integrity": "sha512-va1DQv4nuvZl3M01LaKwZHNXwWfdwBwy9lnQtIZrK0/khU0b9xTd6U1mkbissKvkDejeDdtEunoihxl9HVl7VA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "^2.4.1",
@@ -1147,6 +1410,9 @@
     },
     "node_modules/subleveldown/node_modules/abstract-leveldown": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "xtend": "~4.0.0"
@@ -1154,6 +1420,9 @@
     },
     "node_modules/subleveldown/node_modules/deferred-leveldown": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
@@ -1161,6 +1430,9 @@
     },
     "node_modules/subleveldown/node_modules/levelup": {
       "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
       "license": "MIT",
       "dependencies": {
         "deferred-leveldown": "~1.2.1",
@@ -1174,10 +1446,14 @@
     },
     "node_modules/subleveldown/node_modules/prr": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "license": "MIT"
     },
     "node_modules/subleveldown/node_modules/semver": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -1185,6 +1461,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1195,6 +1473,8 @@
     },
     "node_modules/through2": {
       "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
@@ -1203,10 +1483,14 @@
     },
     "node_modules/through2/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/through2/node_modules/readable-stream": {
       "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -1217,10 +1501,14 @@
     },
     "node_modules/through2/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -1231,10 +1519,14 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
     "node_modules/uiohook-napi": {
-      "version": "1.5.2",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/uiohook-napi/-/uiohook-napi-1.5.4.tgz",
+      "integrity": "sha512-7vPVDNwgb6MwTgviA/dnF2MrW0X5xm76fAqaOAC3cEKkswqAZOPw1USu14Sr6383s5qhXegcJaR63CpJOPCNAg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1246,18 +1538,26 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/varint": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz",
+      "integrity": "sha512-vu4cpCqZHA4u77jWdOZlXtXHJofIIyq51DtzstbrvI9e1I1ELseAJLxYr47N/DdLPFGfYMLY1HqAURSTKKJ6ww==",
       "license": "MIT"
     },
     "node_modules/vlq": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "license": "MIT"
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1265,910 +1565,18 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
-    }
-  },
-  "dependencies": {
-    "@ffmpeg-installer/darwin-arm64": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-arm64/-/darwin-arm64-4.1.5.tgz",
-      "integrity": "sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==",
-      "optional": true
-    },
-    "@ffmpeg-installer/darwin-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/darwin-x64/-/darwin-x64-4.1.0.tgz",
-      "integrity": "sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==",
-      "optional": true
-    },
-    "@ffmpeg-installer/ffmpeg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
-      "integrity": "sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==",
-      "requires": {
-        "@ffmpeg-installer/darwin-arm64": "4.1.5",
-        "@ffmpeg-installer/darwin-x64": "4.1.0",
-        "@ffmpeg-installer/linux-arm": "4.1.3",
-        "@ffmpeg-installer/linux-arm64": "4.1.4",
-        "@ffmpeg-installer/linux-ia32": "4.1.0",
-        "@ffmpeg-installer/linux-x64": "4.1.0",
-        "@ffmpeg-installer/win32-ia32": "4.1.0",
-        "@ffmpeg-installer/win32-x64": "4.1.0"
-      }
-    },
-    "@ffmpeg-installer/linux-arm": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm/-/linux-arm-4.1.3.tgz",
-      "integrity": "sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==",
-      "optional": true
-    },
-    "@ffmpeg-installer/linux-arm64": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-arm64/-/linux-arm64-4.1.4.tgz",
-      "integrity": "sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==",
-      "optional": true
-    },
-    "@ffmpeg-installer/linux-ia32": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-ia32/-/linux-ia32-4.1.0.tgz",
-      "integrity": "sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==",
-      "optional": true
-    },
-    "@ffmpeg-installer/linux-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/linux-x64/-/linux-x64-4.1.0.tgz",
-      "integrity": "sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==",
-      "optional": true
-    },
-    "@ffmpeg-installer/win32-ia32": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-ia32/-/win32-ia32-4.1.0.tgz",
-      "integrity": "sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==",
-      "optional": true
-    },
-    "@ffmpeg-installer/win32-x64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg-installer/win32-x64/-/win32-x64-4.1.0.tgz",
-      "integrity": "sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==",
-      "optional": true
-    },
-    "@ffprobe-installer/darwin-arm64": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-arm64/-/darwin-arm64-5.0.1.tgz",
-      "integrity": "sha512-vwNCNjokH8hfkbl6m95zICHwkSzhEvDC3GVBcUp5HX8+4wsX10SP3B+bGur7XUzTIZ4cQpgJmEIAx6TUwRepMg==",
-      "optional": true
-    },
-    "@ffprobe-installer/darwin-x64": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/darwin-x64/-/darwin-x64-5.1.0.tgz",
-      "integrity": "sha512-J+YGscZMpQclFg31O4cfVRGmDpkVsQ2fZujoUdMAAYcP0NtqpC49Hs3SWJpBdsGB4VeqOt5TTm1vSZQzs1NkhA==",
-      "optional": true
-    },
-    "@ffprobe-installer/ffprobe": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/ffprobe/-/ffprobe-2.1.2.tgz",
-      "integrity": "sha512-ZNvwk4f2magF42Zji2Ese16SMj9BS7Fui4kRjg6gTYTxY3gWZNpg85n4MIfQyI9nimHg4x/gT6FVkp/bBDuBwg==",
-      "requires": {
-        "@ffprobe-installer/darwin-arm64": "5.0.1",
-        "@ffprobe-installer/darwin-x64": "5.1.0",
-        "@ffprobe-installer/linux-arm": "5.2.0",
-        "@ffprobe-installer/linux-arm64": "5.2.0",
-        "@ffprobe-installer/linux-ia32": "5.2.0",
-        "@ffprobe-installer/linux-x64": "5.2.0",
-        "@ffprobe-installer/win32-ia32": "5.1.0",
-        "@ffprobe-installer/win32-x64": "5.1.0"
-      }
-    },
-    "@ffprobe-installer/linux-arm": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm/-/linux-arm-5.2.0.tgz",
-      "integrity": "sha512-PF5HqEhCY7WTWHtLDYbA/+rLS+rhslWvyBlAG1Fk8VzVlnRdl93o6hy7DE2kJgxWQbFaR3ZktPQGEzfkrmQHvQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-arm64": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-arm64/-/linux-arm64-5.2.0.tgz",
-      "integrity": "sha512-X1VvWtlLs6ScP73biVLuHD5ohKJKsMTa0vafCESOen4mOoNeLAYbxOVxDWAdFz9cpZgRiloFj5QD6nDj8E28yQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-ia32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-ia32/-/linux-ia32-5.2.0.tgz",
-      "integrity": "sha512-TFVK5sasXyXhbIG7LtPRDmtkrkOsInwKcL43iEvEw+D9vCS2rc//mn9/0Q+BR0UoJEiMK4+ApYr/3LLVUBPOCQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/linux-x64": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/linux-x64/-/linux-x64-5.2.0.tgz",
-      "integrity": "sha512-D3UeqTLYPNs7pBWPLUYGehPdRVqU8eACox4OZy3pZUZatxye2YKlvBwEfaLdL1v2Z4FOAlLUhms0kY8m8kqSRA==",
-      "optional": true
-    },
-    "@ffprobe-installer/win32-ia32": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-ia32/-/win32-ia32-5.1.0.tgz",
-      "integrity": "sha512-5O3vOoNRxmut0/Nu9vSazTdSHasrr+zPT2B3Hm7kjmO3QVFcIfVImS6ReQnZeSy8JPJOqXts5kX5x/3KOX54XQ==",
-      "optional": true
-    },
-    "@ffprobe-installer/win32-x64": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ffprobe-installer/win32-x64/-/win32-x64-5.1.0.tgz",
-      "integrity": "sha512-jMGYeAgkrdn4e2vvYt/qakgHRE3CPju4bn5TmdPfoAm1BlX1mY9cyMd8gf5vSzI8gH8Zq5WQAyAkmekX/8TSTg==",
-      "optional": true
-    },
-    "abstract-leveldown": {
-      "version": "2.7.2",
-      "requires": {
-        "xtend": "~4.0.0"
-      }
-    },
-    "acorn": {
-      "version": "7.4.1"
-    },
-    "atomic-queue": {
-      "version": "5.0.4",
-      "requires": {
-        "changes-feed": "^1.1.0",
-        "changesdown": "^2.3.0",
-        "debug": "^2.1.2",
-        "duplexify": "^3.2.0",
-        "hat": "0.0.3",
-        "inherits": "^2.0.1",
-        "memdb": "^0.2.0",
-        "pumpify": "^1.3.3",
-        "subleveldown": "^2.0.0",
-        "through2": "^0.6.3"
-      }
-    },
-    "bl": {
-      "version": "0.8.2",
-      "requires": {
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        }
-      }
-    },
-    "brfs": {
-      "version": "1.6.1",
-      "requires": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "2.0.5",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
-    "buffer-equal": {
-      "version": "0.0.1"
-    },
-    "buffer-from": {
-      "version": "1.1.2"
-    },
-    "changes-feed": {
-      "version": "1.1.0",
-      "requires": {
-        "from2": "^1.3.0",
-        "lexicographic-integer": "^1.1.0",
-        "mutexify": "^1.0.1",
-        "pump": "^1.0.0",
-        "stream-collector": "^1.0.1",
-        "through2": "^0.6.3"
-      }
-    },
-    "changesdown": {
-      "version": "2.3.1",
-      "requires": {
-        "abstract-leveldown": "^2.1.0",
-        "brfs": "^1.4.0",
-        "levelup": "^0.19.0",
-        "protocol-buffers": "^2.4.6",
-        "pump": "^1.0.0",
-        "subleveldown": "^1.1.0",
-        "through2": "^0.6.3"
-      },
-      "dependencies": {
-        "subleveldown": {
-          "version": "1.1.0",
-          "requires": {
-            "abstract-leveldown": "^2.1.0",
-            "level-option-wrap": "^1.1.0",
-            "levelup": "^0.19.0"
-          }
-        }
-      }
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "convert-source-map": {
-      "version": "1.9.0"
-    },
-    "core-util-is": {
-      "version": "1.0.3"
-    },
-    "debug": {
-      "version": "2.6.9",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.4"
-    },
-    "deferred-leveldown": {
-      "version": "0.2.0",
-      "requires": {
-        "abstract-leveldown": "~0.12.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "requires": {
-            "xtend": "~3.0.0"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0"
-        }
-      }
-    },
-    "defined": {
-      "version": "0.0.0"
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "requires": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "duplexify": {
-      "version": "3.7.1",
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.8",
-      "requires": {
-        "prr": "~1.0.1"
-      },
-      "dependencies": {
-        "prr": {
-          "version": "1.0.1"
-        }
-      }
-    },
-    "escodegen": {
-      "version": "1.9.1",
-      "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      }
-    },
-    "esprima": {
-      "version": "3.1.3"
-    },
-    "estraverse": {
-      "version": "4.3.0"
-    },
-    "esutils": {
-      "version": "2.0.3"
-    },
-    "falafel": {
-      "version": "2.2.5",
-      "requires": {
-        "acorn": "^7.1.1",
-        "isarray": "^2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5"
-        }
-      }
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6"
-    },
-    "from2": {
-      "version": "1.3.0",
-      "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~1.1.10"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        }
-      }
-    },
-    "function-bind": {
-      "version": "1.1.1"
-    },
-    "generate-function": {
-      "version": "2.3.1",
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "requires": {
-        "is-property": "^1.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "hat": {
-      "version": "0.0.3"
-    },
-    "inherits": {
-      "version": "2.0.4"
-    },
-    "is-core-module": {
-      "version": "2.11.0",
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "is-property": {
-      "version": "1.0.2"
-    },
-    "isarray": {
-      "version": "1.0.0"
-    },
-    "level-codec": {
-      "version": "7.0.1"
-    },
-    "level-errors": {
-      "version": "1.0.5",
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "1.3.1",
-      "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        }
-      }
-    },
-    "level-option-wrap": {
-      "version": "1.1.0",
-      "requires": {
-        "defined": "~0.0.0"
-      }
-    },
-    "levelup": {
-      "version": "0.19.1",
-      "requires": {
-        "bl": "~0.8.1",
-        "deferred-leveldown": "~0.2.0",
-        "errno": "~0.1.1",
-        "prr": "~0.0.0",
-        "readable-stream": "~1.0.26",
-        "semver": "~5.1.0",
-        "xtend": "~3.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        },
-        "xtend": {
-          "version": "3.0.0"
-        }
-      }
-    },
-    "levn": {
-      "version": "0.3.0",
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
-    },
-    "lexicographic-integer": {
-      "version": "1.1.0"
-    },
-    "magic-string": {
-      "version": "0.22.5",
-      "requires": {
-        "vlq": "^0.2.2"
-      }
-    },
-    "memdb": {
-      "version": "0.2.0",
-      "requires": {
-        "levelup": "~0.18.3",
-        "memdown": "~0.8.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "levelup": {
-          "version": "0.18.6",
-          "requires": {
-            "bl": "~0.8.1",
-            "deferred-leveldown": "~0.2.0",
-            "errno": "~0.1.1",
-            "prr": "~0.0.0",
-            "readable-stream": "~1.0.26",
-            "semver": "~2.3.1",
-            "xtend": "~3.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "semver": {
-          "version": "2.3.2"
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        },
-        "xtend": {
-          "version": "3.0.0"
-        }
-      }
-    },
-    "memdown": {
-      "version": "0.8.0",
-      "requires": {
-        "abstract-leveldown": "~0.12.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "requires": {
-            "xtend": "~3.0.0"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0"
-        }
-      }
-    },
-    "merge-source-map": {
-      "version": "1.0.4",
-      "requires": {
-        "source-map": "^0.5.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7"
-        }
-      }
-    },
-    "minimist": {
-      "version": "1.2.7"
-    },
-    "ms": {
-      "version": "2.0.0"
-    },
-    "mutexify": {
-      "version": "1.4.0",
-      "requires": {
-        "queue-tick": "^1.0.0"
-      }
-    },
-    "node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="
-    },
-    "node-gyp-build": {
-      "version": "4.6.1"
-    },
-    "noobs": {
-      "version": "0.0.181",
-      "resolved": "https://registry.npmjs.org/noobs/-/noobs-0.0.181.tgz",
-      "integrity": "sha512-wQuDX910TiW02msJoPfLt4y6d84bZhQUZdt2+zglrY60lDlcXJIXZV2twX368AFIaPXEXZME5p0HgNxIvyjwRw==",
-      "requires": {
-        "node-addon-api": "^8.4.0"
-      }
-    },
-    "object-inspect": {
-      "version": "1.4.1"
-    },
-    "once": {
-      "version": "1.4.0",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "optionator": {
-      "version": "0.8.3",
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      }
-    },
-    "path-parse": {
-      "version": "1.0.7"
-    },
-    "prelude-ls": {
-      "version": "1.1.2"
-    },
-    "process-nextick-args": {
-      "version": "2.0.1"
-    },
-    "protobuf-schema": {
-      "version": "1.5.1"
-    },
-    "protocol-buffers": {
-      "version": "2.7.0",
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "protobuf-schema": "^1.5.0",
-        "resolve-protobuf-schema": "^1.0.2",
-        "signed-varint": "^2.0.0",
-        "varint": "^4.0.0"
-      }
-    },
-    "prr": {
-      "version": "0.0.0"
-    },
-    "pump": {
-      "version": "1.0.3",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "1.5.1",
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "queue-tick": {
-      "version": "1.0.1"
-    },
-    "quote-stream": {
-      "version": "1.0.2",
-      "requires": {
-        "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "2.0.5",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "resolve": {
-      "version": "1.22.1",
-      "requires": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "resolve-protobuf-schema": {
-      "version": "1.0.2",
-      "requires": {
-        "protobuf-schema": "^1.2.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2"
-    },
-    "semver": {
-      "version": "5.1.1"
-    },
-    "shallow-copy": {
-      "version": "0.0.1"
-    },
-    "signed-varint": {
-      "version": "2.0.1",
-      "requires": {
-        "varint": "~5.0.0"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2"
-        }
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "optional": true
-    },
-    "static-eval": {
-      "version": "2.1.0",
-      "requires": {
-        "escodegen": "^1.11.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.14.3",
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1"
-        }
-      }
-    },
-    "static-module": {
-      "version": "2.2.5",
-      "requires": {
-        "concat-stream": "~1.6.0",
-        "convert-source-map": "^1.5.1",
-        "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
-        "falafel": "^2.1.0",
-        "has": "^1.0.1",
-        "magic-string": "^0.22.4",
-        "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
-        "quote-stream": "~1.0.2",
-        "readable-stream": "~2.3.3",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.0",
-        "through2": "~2.0.3"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "2.0.5",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
-    "stream-collector": {
-      "version": "1.0.1",
-      "requires": {
-        "once": "^1.3.1"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.1"
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "subleveldown": {
-      "version": "2.1.0",
-      "requires": {
-        "abstract-leveldown": "^2.4.1",
-        "level-option-wrap": "^1.1.0",
-        "levelup": "^1.2.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "requires": {
-            "abstract-leveldown": "~2.6.0"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
-          }
-        },
-        "prr": {
-          "version": "1.0.1"
-        },
-        "semver": {
-          "version": "5.4.1"
-        }
-      }
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0"
-    },
-    "through2": {
-      "version": "0.6.5",
-      "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31"
-        }
-      }
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6"
-    },
-    "uiohook-napi": {
-      "version": "1.5.2",
-      "requires": {
-        "node-gyp-build": "4.x.x"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2"
-    },
-    "varint": {
-      "version": "4.0.1"
-    },
-    "vlq": {
-      "version": "0.2.3"
-    },
-    "word-wrap": {
-      "version": "1.2.3"
-    },
-    "wrappy": {
-      "version": "1.0.2"
-    },
-    "xtend": {
-      "version": "4.0.2"
     }
   }
 }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -15,7 +15,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "atomic-queue": "^5.0.4",
-    "noobs": "^0.0.181",
+    "noobs": "file:../../../noobs-linux",
     "uiohook-napi": "^1.5.2"
   },
   "license": "MIT"

--- a/src/main/obsEnums.ts
+++ b/src/main/obsEnums.ts
@@ -20,6 +20,8 @@ export enum ESupportedEncoders {
   NVENC_AV1 = 'obs_nvenc_av1_tex',
   QSV_H264 = 'obs_qsv11_soft_v2',
   QSV_AV1 = 'obs_qsv11_av1',
+  VAAPI_H264 = 'ffmpeg_vaapi',
+  LINUX_NVENC_H264 = 'ffmpeg_nvenc',
 }
 
 export enum QualityPresets {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -603,6 +603,8 @@ enum VideoSourceName {
   GAME = 'WCR Game Capture',
   MONITOR = 'WCR Monitor Capture',
   OVERLAY = 'WCR Chat Overlay',
+  // Linux uses a unified capture source since all modes use PipeWire
+  LINUX_CAPTURE = 'WCR Capture',
 }
 
 enum AudioSourcePrefix {

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Platform detection utilities for cross-platform support.
+ */
+
+const getPlatform = (): string => {
+  if (typeof process !== 'undefined' && process.platform) {
+    return process.platform;
+  }
+  if (typeof navigator !== 'undefined' && navigator.platform) {
+    const navPlatform = navigator.platform.toLowerCase();
+    if (navPlatform.includes('linux')) return 'linux';
+    if (navPlatform.includes('mac')) return 'darwin';
+    if (navPlatform.includes('win')) return 'win32';
+  }
+  return 'win32';
+};
+
+const platform = getPlatform();
+
+export const isLinux = platform === 'linux';
+export const isWindows = platform === 'win32';
+export const isMac = platform === 'darwin';
+
+export const getFileManagerCommand = (filePath: string): string => {
+  if (isLinux) {
+    const dirPath = filePath.substring(0, filePath.lastIndexOf('/'));
+    return `xdg-open "${dirPath}"`;
+  }
+  if (isMac) {
+    return `open -R "${filePath}"`;
+  }
+  const windowsPath = filePath.replace(/\//g, '\\');
+  return `explorer.exe /select,"${windowsPath}"`;
+};
+
+/**
+ * Maps AudioSourceType enum values to platform-specific OBS source type strings.
+ */
+export const getObsAudioSourceType = (audioSourceType: string): string => {
+  if (isLinux) {
+    const linuxMapping: Record<string, string> = {
+      'wasapi_output_capture': 'pulse_output_capture',
+      'wasapi_input_capture': 'pulse_input_capture',
+      'wasapi_process_output_capture': 'pulse_output_capture',
+    };
+    return linuxMapping[audioSourceType] || audioSourceType;
+  }
+  return audioSourceType;
+};
+
+/**
+ * Check if process-specific audio capture is available on the current platform.
+ */
+export const isProcessAudioCaptureAvailable = (): boolean => {
+  return !isLinux;
+};
+
+/**
+ * Get the graphics module name for OBS based on platform.
+ */
+export const getObsGraphicsModule = (): string => {
+  if (isLinux) {
+    return 'libobs-opengl';
+  }
+  return 'libobs-d3d11';
+};
+
+/**
+ * Get the appropriate OBS capture source type for the current platform.
+ */
+export const getObsCaptureSourceType = (captureMode: string): string => {
+  if (isLinux) {
+    return 'pipewire-screen-capture-source';
+  }
+  return captureMode;
+};
+
+/**
+ * Check if the given capture mode is available on the current platform.
+ */
+export const isCaptureSourceAvailable = (captureMode: string): boolean => {
+  return true;
+};

--- a/src/platform/linux/processDetector.ts
+++ b/src/platform/linux/processDetector.ts
@@ -1,0 +1,145 @@
+/**
+ * Linux-specific WoW process detection.
+ * Scans /proc filesystem for Wine/Proton processes running WoW executables.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import EventEmitter from 'events';
+
+// WoW executable names to detect
+const WOW_RETAIL_EXECUTABLES = ['Wow.exe', 'WowT.exe', 'WowB.exe'];
+const WOW_CLASSIC_EXECUTABLES = ['WowClassic.exe', 'WowClassicT.exe'];
+const ALL_WOW_EXECUTABLES = [...WOW_RETAIL_EXECUTABLES, ...WOW_CLASSIC_EXECUTABLES];
+
+export interface ProcessDetectorResult {
+  Retail: boolean;
+  Classic: boolean;
+}
+
+/**
+ * Reads the command line of a process from /proc/[pid]/cmdline.
+ * Returns null if the process doesn't exist or can't be read.
+ */
+async function readProcessCmdline(pid: string): Promise<string | null> {
+  try {
+    const cmdlinePath = path.join('/proc', pid, 'cmdline');
+    const content = await fs.readFile(cmdlinePath, 'utf-8');
+    return content.replace(/\0/g, ' ').trim();
+  } catch {
+    // Process may have exited or we don't have permission
+    return null;
+  }
+}
+
+/**
+ * Checks if a command line indicates a Wine/Proton process running WoW.
+ * Wine processes typically have the executable name in the cmdline.
+ */
+function isWowProcess(cmdline: string): { isRetail: boolean; isClassic: boolean } {
+  const cmdlineLower = cmdline.toLowerCase();
+
+  const isWineProcess = cmdlineLower.includes('wine') ||
+                        cmdlineLower.includes('proton') ||
+                        cmdlineLower.includes('.exe');
+
+  if (!isWineProcess) {
+    return { isRetail: false, isClassic: false };
+  }
+
+  const isRetail = WOW_RETAIL_EXECUTABLES.some(exe =>
+    cmdlineLower.includes(exe.toLowerCase())
+  );
+
+  const isClassic = WOW_CLASSIC_EXECUTABLES.some(exe =>
+    cmdlineLower.includes(exe.toLowerCase())
+  );
+
+  return { isRetail, isClassic };
+}
+
+/**
+ * Scans all processes in /proc to find WoW instances.
+ */
+export async function detectWowProcesses(): Promise<ProcessDetectorResult> {
+  let retailFound = false;
+  let classicFound = false;
+
+  try {
+    const entries = await fs.readdir('/proc');
+
+    // Filter to only numeric directories (PIDs)
+    const pids = entries.filter(entry => /^\d+$/.test(entry));
+
+    const checks = pids.map(async (pid) => {
+      const cmdline = await readProcessCmdline(pid);
+      if (cmdline) {
+        const { isRetail, isClassic } = isWowProcess(cmdline);
+        if (isRetail) retailFound = true;
+        if (isClassic) classicFound = true;
+      }
+    });
+
+    await Promise.all(checks);
+  } catch (error) {
+    console.error('[LinuxProcessDetector] Error scanning /proc:', error);
+  }
+
+  return {
+    Retail: retailFound,
+    Classic: classicFound,
+  };
+}
+
+/**
+ * Linux process detector class that mimics the interface expected by Poller.
+ * Periodically scans /proc and emits results.
+ */
+export class LinuxProcessDetector extends EventEmitter {
+  private intervalId: NodeJS.Timeout | null = null;
+  private pollInterval: number;
+
+  constructor(pollIntervalMs: number = 1000) {
+    super();
+    this.pollInterval = pollIntervalMs;
+  }
+
+  /**
+   * Start polling for WoW processes.
+   */
+  start(): void {
+    if (this.intervalId) {
+      this.stop();
+    }
+
+    console.info('[LinuxProcessDetector] Starting process polling');
+
+    this.poll();
+    this.intervalId = setInterval(() => this.poll(), this.pollInterval);
+  }
+
+  /**
+   * Stop polling.
+   */
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+      console.info('[LinuxProcessDetector] Stopped process polling');
+    }
+  }
+
+  /**
+   * Perform a single poll and emit the result.
+   */
+  private async poll(): Promise<void> {
+    try {
+      const result = await detectWowProcesses();
+      this.emit('data', JSON.stringify(result));
+    } catch (error) {
+      this.emit('error', error);
+    }
+  }
+}
+
+export default LinuxProcessDetector;

--- a/src/renderer/AudioSourceControls.tsx
+++ b/src/renderer/AudioSourceControls.tsx
@@ -1,4 +1,5 @@
 import { AppState, AudioSource, AudioSourceType } from 'main/types';
+import { isProcessAudioCaptureAvailable } from 'platform';
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { configSchema } from 'config/configSchema';
 import {
@@ -734,14 +735,16 @@ const AudioSourceControls = (props: IProps) => {
             <PlusIcon className="px-0" />
             {getLocalePhrase(language, Phrase.AddMicrophoneButtonText)}
           </Button>
-          <Button
-            onClick={() => addSource(AudioSourceType.PROCESS)}
-            disabled={!sourcesAreFullyDefined}
-            variant="outline"
-          >
-            <PlusIcon className="px-0" />
-            {getLocalePhrase(language, Phrase.AddApplicationButtonText)}
-          </Button>
+          {isProcessAudioCaptureAvailable() && (
+            <Button
+              onClick={() => addSource(AudioSourceType.PROCESS)}
+              disabled={!sourcesAreFullyDefined}
+              variant="outline"
+            >
+              <PlusIcon className="px-0" />
+              {getLocalePhrase(language, Phrase.AddApplicationButtonText)}
+            </Button>
+          )}
         </div>
       </div>
     );

--- a/src/renderer/VideoSourceControls.tsx
+++ b/src/renderer/VideoSourceControls.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { AppState, OurDisplayType } from 'main/types';
 import { configSchema } from 'config/configSchema';
-import { Info } from 'lucide-react';
+import { Info, MonitorPlay } from 'lucide-react';
 import { getLocalePhrase } from 'localisation/translations';
 import { useSettings, setConfigValues } from './useSettings';
 import Label from './components/Label/Label';
@@ -12,6 +12,8 @@ import {
 import Switch from './components/Switch/Switch';
 import { Tooltip } from './components/Tooltip/Tooltip';
 import { Phrase } from 'localisation/phrases';
+import { isLinux } from '../platform';
+import { Button } from './components/Button/Button';
 
 const ipc = window.electron.ipcRenderer;
 
@@ -92,7 +94,40 @@ const VideoSourceControls = (props: IProps) => {
     });
   };
 
+  const handleSelectSource = async () => {
+    await ipc.invoke('selectCaptureSource', []);
+  };
+
+  const getLinuxSourceSelector = () => {
+    return (
+      <div>
+        <Label className="flex items-center">
+          Capture Source
+          <Tooltip
+            content="Click to open the source picker and select what to capture (window, screen, etc.)"
+            side="right"
+          >
+            <Info size={20} className="inline-flex ml-2" />
+          </Tooltip>
+        </Label>
+        <Button
+          onClick={handleSelectSource}
+          variant="outline"
+          size="sm"
+          className="flex items-center gap-2"
+        >
+          <MonitorPlay size={16} />
+          Select Source
+        </Button>
+      </div>
+    );
+  };
+
   const getCaptureModeToggle = () => {
+    if (isLinux) {
+      return getLinuxSourceSelector();
+    }
+
     return (
       <div>
         <Label className="flex items-center">
@@ -129,7 +164,7 @@ const VideoSourceControls = (props: IProps) => {
   };
 
   const getMonitorToggle = () => {
-    if (config.obsCaptureMode !== 'monitor_capture') {
+    if (isLinux || config.obsCaptureMode !== 'monitor_capture') {
       return <></>;
     }
 


### PR DESCRIPTION
## Summary

- Add Linux platform support to the Electron app alongside existing Windows support
- PipeWire-based video capture with interactive source selection
- Linux WoW process detection by scanning /proc for Wine/Proton processes
- FFmpeg-based video trimming using -sseof (trim from end) for the replay-buffer-save-at-end strategy
- Multi-distro obs-ffmpeg-mux discovery and symlinking
- Linux hardware encoder support (VA-API, NVENC via FFmpeg)
- Cross-platform abstraction layer in src/platform/

## Details

### Platform abstraction (`src/platform/`)
New module providing `isLinux`/`isWindows`/`isMac` flags and platform-specific helpers. Works in both main and renderer processes by using `navigator.platform` in renderer and `process.platform` in main.

### Process detection (`src/platform/linux/processDetector.ts`)
Replaces the Windows `rust-ps.exe` binary on Linux. Periodically scans `/proc/[pid]/cmdline` for Wine/Proton processes running WoW executables (Wow.exe, WowClassic.exe, etc.) and emits JSON compatible with the existing Poller interface.

### Video capture
All Linux capture modes route through PipeWire (`pipewire-screen-capture-source`). The user picks a capture source via an interactive PipeWire dialog. The selected source persists across recording sessions.

### Video processing
Linux saves the full replay buffer at encounter end, then trims from the end using `ffmpeg -sseof`. This avoids the timing offset issues that would arise from PipeWire sources not being available at encounter start.

### Encoder support
Added `VAAPI_H264` (ffmpeg_vaapi) and `LINUX_NVENC_H264` (ffmpeg_nvenc) to the supported encoders enum. Updated encoder settings and auto-detection to prefer hardware encoding on Linux when available.

### Muxer setup
`obs-ffmpeg-mux` is discovered from known distro paths (Fedora, Debian/Ubuntu, Arch) and symlinked into the Electron app directory at startup.

## Test plan

- [x] Tested on Fedora 43 with PipeWire, NVIDIA GPU
- [ ] Test on Debian/Ubuntu-based distro
- [ ] Test on Arch-based distro
- [ ] Verify Windows functionality is not affected