### PR TITLE
Hide scene preview and widen hover card on cloud status card.

### DIFF
--- a/src/renderer/SideMenu.tsx
+++ b/src/renderer/SideMenu.tsx
@@ -263,7 +263,10 @@ const SideMenu = (props: IProps) => {
         advancedLoggingStatus={advancedLoggingStatus}
         setPreviewEnabled={setPreviewEnabled}
       />
-      <CloudStatusCard appState={appState} />
+      <CloudStatusCard
+        appState={appState}
+        setPreviewEnabled={setPreviewEnabled}
+      />
       <Separator className="mb-4" />
       <ScrollArea
         className="w-full h-[calc(100%-80px)]"

--- a/src/renderer/containers/ApplicationStatusCard/CloudStatus.tsx
+++ b/src/renderer/containers/ApplicationStatusCard/CloudStatus.tsx
@@ -2,7 +2,7 @@ import { Phrase } from 'localisation/phrases';
 import { getLocalePhrase } from 'localisation/translations';
 import { CloudDownload, CloudUpload } from 'lucide-react';
 import { AppState, CloudState } from 'main/types';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import {
   HoverCard,
   HoverCardContent,
@@ -15,11 +15,12 @@ import StatusLight, {
 
 type StatusProps = {
   appState: AppState;
+  setPreviewEnabled: Dispatch<SetStateAction<boolean>>;
 };
 
 const ipc = window.electron.ipcRenderer;
 
-const CloudStatus = ({ appState }: StatusProps) => {
+const CloudStatus = ({ appState, setPreviewEnabled }: StatusProps) => {
   const { cloudStatus, language } = appState;
 
   const [cloudState, setCloudState] = useState<CloudState>({
@@ -161,7 +162,10 @@ const CloudStatus = ({ appState }: StatusProps) => {
   };
 
   return (
-    <HoverCard openDelay={300}>
+    <HoverCard
+      openDelay={300}
+      onOpenChange={(open) => setPreviewEnabled(!open)}
+    >
       <HoverCardTrigger>
         <div className="w-full h-full flex relative rounded-md border-t border-[rgba(255,255,255,10%)] hover:cursor-pointer">
           <StatusLight
@@ -183,7 +187,7 @@ const CloudStatus = ({ appState }: StatusProps) => {
             {renderUploadIcon()}
           </div>
         </div>
-        <HoverCardContent className="w-[260px] mx-4">
+        <HoverCardContent className="w-fit mx-4">
           {description}
         </HoverCardContent>
       </HoverCardTrigger>

--- a/src/renderer/containers/ApplicationStatusCard/CloudStatusCard.tsx
+++ b/src/renderer/containers/ApplicationStatusCard/CloudStatusCard.tsx
@@ -1,12 +1,17 @@
+import { Dispatch, SetStateAction } from 'react';
 import { AppState } from 'main/types';
 
 import CloudStatus from './CloudStatus';
 
 type CloudStatusCardProps = {
   appState: AppState;
+  setPreviewEnabled: Dispatch<SetStateAction<boolean>>;
 };
 
-const CloudStatusCard = ({ appState }: CloudStatusCardProps) => {
+const CloudStatusCard = ({
+  appState,
+  setPreviewEnabled,
+}: CloudStatusCardProps) => {
   return (
     <div className="w-full h-14 rounded-md mb-4 flex relative">
       <div
@@ -23,7 +28,10 @@ const CloudStatusCard = ({ appState }: CloudStatusCardProps) => {
           id="gradient-layer"
           className="w-full h-full rounded-md bg-gradient-to-r from-background-dark-gradient-from to-transparent absolute"
         />
-        <CloudStatus appState={appState} />
+        <CloudStatus
+          appState={appState}
+          setPreviewEnabled={setPreviewEnabled}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Closes

- #810

## What

 - Wires the cloud status card's HoverCard to setPreviewEnabled so the scene preview hides while the popup is open. The recorder card already did this after #796; the cloud card got missed.
 - Drops the fixed w-[260px] on the cloud hover card in favour of w-fit so it sizes to its content.
 - Passes setPreviewEnabled through SideMenu > CloudStatusCard > CloudStatus. There's no new state. The lifted state from #796 already lives in App.tsx.

## Why

- #810 pointed out the cloud card's popup was narrower than the recorder one and didn't hide the scene preview.
- CloudStatus.tsx and CloudStatusCard.tsx are basically copies of the recorder files that I forgot to touch during #796.

## How to test

1. Open the app on the Scene Editor page with the WoW preview showing.
2. Hover the cloud status card and check:
    - Nothing gets clipped.
    - The scene preview disappears while the popup is open, and comes back when it closes.
    - The popup width fits its content rather than being stuck at ~260px.
3. Hover the recorder card to make sure its hide-preview behaviour still works.
4. Open the cloud popup, then slide over to the recorder card without closing it. The preview should stay hidden the whole time.