### PR TITLE
[codex] Fix Mythic+ timer result handling

### DIFF
--- a/src/__tests__/activitys/ChallengeModeDungeon.test.ts
+++ b/src/__tests__/activitys/ChallengeModeDungeon.test.ts
@@ -133,7 +133,7 @@ test('Hard Depleted Challenge Mode', () => {
   expect(dungeon.upgradeLevel).toBe(0);
 });
 
-test('Peril Timed Challenge Mode', () => {
+test('Peril Does Not Extend Timer', () => {
   const startDate = new Date('2022-12-25T12:00:00');
   const endDate = getRelativeDate(startDate, 34 * 60); // Over the base time of 33 mins
 
@@ -169,7 +169,7 @@ test('Peril Timed Challenge Mode', () => {
   expect(dungeon.CMDuration).toBe(34 * 60);
 
   expect(dungeon.result).toBe(true);
-  expect(dungeon.upgradeLevel).toBe(1);
+  expect(dungeon.upgradeLevel).toBe(0);
 });
 
 test('Peril Depleted Challenge Mode', () => {

--- a/src/__tests__/activitys/ChallengeModeDungeon.test.ts
+++ b/src/__tests__/activitys/ChallengeModeDungeon.test.ts
@@ -1,9 +1,19 @@
+jest.mock(
+  'config/ConfigService',
+  () => ({
+    __esModule: true,
+    default: {
+      getInstance: () => ({
+        get: () => 'English',
+      }),
+    },
+  }),
+  { virtual: true },
+);
+
 import { Flavour, PlayerDeathType } from '../../main/types';
 import ChallengeModeDungeon from '../../activitys/ChallengeModeDungeon';
 import Combatant from '../../main/Combatant';
-import TestConfigService from '../../utils/TestConfigService';
-
-const cfg = new TestConfigService();
 
 const getPlayerDeath = (deathDate: Date, rel: number, isFriendly: boolean) => {
   const playerDeath: PlayerDeathType = {
@@ -38,8 +48,7 @@ test('Basic Challenge Mode', () => {
     1822,
     353,
     10,
-    [159, 10, 152, 9], // Peril included
-    cfg,
+    [159, 10, 152, 9],
     Flavour.Retail,
   );
 
@@ -90,8 +99,7 @@ test('Hard Depleted Challenge Mode', () => {
     1822,
     353,
     10,
-    [159, 10, 152, 9], // Peril included
-    cfg,
+    [159, 10, 152, 9],
     Flavour.Retail,
   );
 
@@ -142,8 +150,7 @@ test('Peril Timed Challenge Mode', () => {
     1822,
     353,
     10,
-    [159, 10, 152, 9], // Peril included so we get +90 on the timer
-    cfg,
+    [159, 10, 152, 9],
     Flavour.Retail,
   );
 
@@ -182,8 +189,7 @@ test('Peril Depleted Challenge Mode', () => {
     1822,
     353,
     10,
-    [159, 10, 152, 9], // Peril included so we get +90 on the timer
-    cfg,
+    [159, 10, 152, 9],
     Flavour.Retail,
   );
 
@@ -214,6 +220,44 @@ test('Peril Depleted Challenge Mode', () => {
   expect(dungeon.duration).toBe(expectedDuration);
   expect(dungeon.deaths.length).toBe(3);
   expect(dungeon.CMDuration).toBe(34 * 60 + 45);
+
+  expect(dungeon.result).toBe(true);
+  expect(dungeon.upgradeLevel).toBe(0);
+});
+
+test('Retail Challenge Mode Allows Timer Grace', () => {
+  const startDate = new Date('2022-12-25T12:00:00');
+  const endDate = getRelativeDate(startDate, 34 * 60 + 0.999);
+
+  const dungeon = new ChallengeModeDungeon(
+    startDate,
+    2875,
+    558,
+    20,
+    [],
+    Flavour.Retail,
+  );
+
+  dungeon.endChallengeMode(endDate, 34 * 60 + 0.999, true);
+
+  expect(dungeon.result).toBe(true);
+  expect(dungeon.upgradeLevel).toBe(1);
+});
+
+test('Retail Challenge Mode Depletes At One Second Over Timer', () => {
+  const startDate = new Date('2022-12-25T12:00:00');
+  const endDate = getRelativeDate(startDate, 34 * 60 + 1);
+
+  const dungeon = new ChallengeModeDungeon(
+    startDate,
+    2875,
+    558,
+    20,
+    [],
+    Flavour.Retail,
+  );
+
+  dungeon.endChallengeMode(endDate, 34 * 60 + 1, true);
 
   expect(dungeon.result).toBe(true);
   expect(dungeon.upgradeLevel).toBe(0);

--- a/src/activitys/ChallengeModeDungeon.ts
+++ b/src/activitys/ChallengeModeDungeon.ts
@@ -99,11 +99,6 @@ export default class ChallengeModeDungeon extends Activity {
       return 0;
     }
 
-    if (this.affixes.includes(152)) {
-      // Challenger's Peril
-      this.CMDuration -= 90;
-    }
-
     const durationForResult = this.CMDuration;
 
     for (let i = this.timings.length - 1; i >= 0; i--) {

--- a/src/activitys/ChallengeModeDungeon.ts
+++ b/src/activitys/ChallengeModeDungeon.ts
@@ -17,6 +17,8 @@ import Activity from './Activity';
 import { app } from 'electron';
 
 export default class ChallengeModeDungeon extends Activity {
+  private static readonly TIMER_GRACE_SECONDS = 1;
+
   private _mapID: number;
 
   private _level: number;
@@ -102,10 +104,13 @@ export default class ChallengeModeDungeon extends Activity {
       this.CMDuration -= 90;
     }
 
-    const durationForResult = Flavour.Classic ? this.CMDuration : this.duration;
+    const durationForResult = this.CMDuration;
 
     for (let i = this.timings.length - 1; i >= 0; i--) {
-      if (durationForResult <= this.timings[i]) {
+      if (
+        durationForResult <
+        this.timings[i] + ChallengeModeDungeon.TIMER_GRACE_SECONDS
+      ) {
         return i + 1;
       }
     }

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -710,7 +710,7 @@ const dungeonTimersByMapId: { [id: number]: number[] } = {
   560: [33 * 60, 26 * 60 + 24, 19 * 60 + 48], // Maisara Caverns
   559: [30 * 60, 24 * 60, 18 * 60], // Nexus-Point Xenas
   557: [33 * 60 + 30, 26 * 60 + 48, 20 * 60 + 6], // Windrunner Spire
-  402: [30 * 60, 30 * 0.8, 30 * 0.6], // Algeth'ar Academy
+  402: [31 * 60, 24 * 60 + 48, 18 * 60 + 36], // Algeth'ar Academy
   556: [30 * 60, 24 * 60, 18 * 60], // Pit of Saron
   239: [34 * 60, 27 * 60 + 12, 20 * 60 + 24], // Seat of the Triumvirate
   161: [28 * 60, 22 * 60 + 36, 16 * 60 + 42], // Skyreach

--- a/src/parsing/RetailLogHandler.ts
+++ b/src/parsing/RetailLogHandler.ts
@@ -247,7 +247,7 @@ export default class RetailLogHandler extends LogHandler {
 
     // The actual log duration of the dungeon, from which keystone upgrade
     // levels can be calculated. This includes player death penalty.
-    const CMDuration = Math.round(parseInt(line.arg(4), 10) / 1000);
+    const CMDuration = parseInt(line.arg(4), 10) / 1000;
 
     if (result) {
       const overrun = ConfigService.getInstance().get<number>('dungeonOverrun');


### PR DESCRIPTION
﻿## Summary

- Update Algeth'ar Academy's Mythic+ timer to 31:00, with matching +2/+3 thresholds.
- Preserve fractional combat-log challenge mode duration instead of rounding to whole seconds.
- Treat runs that finish before `timer + 1s` as timed, matching WoW's visible timer behavior.
- Remove the legacy Challenger's Peril timer adjustment from upgrade calculation.

## Context

The previous M+ result calculation could mark very tight timed keys as depleted because the combat-log duration was rounded before comparison. This keeps the raw fractional duration and applies the one-second timing window used by the game UI.

Challenger's Peril also no longer needs a timer-specific adjustment in recorder. Blizzard's [The War Within Season 2 Mythic+ Updates Ahead](https://worldofwarcraft.blizzard.com/en-us/news/24174877/the-war-within-season-2-mythic-updates-ahead) notes describe the Season 2 affix updates, including Challenger's Peril being replaced at +7 and the death-penalty behavior moving to Xal'atath's Guile at +12.

## Validation

- `npx jest src/__tests__/activitys/ChallengeModeDungeon.test.ts --runInBand --silent`
- `npx eslint src/activitys/ChallengeModeDungeon.ts src/parsing/RetailLogHandler.ts src/main/constants.ts src/__tests__/activitys/ChallengeModeDungeon.test.ts`
