### PR TITLE
Fix audio source cleanup after OBS source rename

### DIFF
--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -788,7 +788,7 @@ export default class Recorder extends EventEmitter {
       }
 
       noobs.AddSourceToScene(name);
-      this.audioSources.push(src);
+      this.audioSources.push({ ...src, id: name });
     });
 
     const mics = this.audioSources.filter(


### PR DESCRIPTION
Related to #799

AI slop below but might be worth a shot 🙃.

OBS may rename a source when `CreateSource()` is called while another source with the requested name already exists, for example `WCR Audio Source 1` becoming `WCR Audio Source 1 2`.

`configureAudioSources()` already uses the OBS-returned name for setup and adding the source to the scene, but it stored the original configured id in `this.audioSources`. Later cleanup then tried to remove/delete the original id instead of the actual OBS source name.

This stores the OBS-returned source name in the active audio source list, so cleanup removes the same source that was added.

Validation:
- Verified locally with an Electron/OBS/noobs smoke test: old behavior removed the requested base name, fixed behavior removed the OBS-returned renamed source.