### PR TITLE
[codex] Fix noobs runtime path for chat overlay

### DIFF
--- a/src/__tests__/main/noobsRuntime.test.ts
+++ b/src/__tests__/main/noobsRuntime.test.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+import { getNoobsBinPath, getNoobsDistPath } from '../../main/noobsRuntimePath';
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalPath = process.env.PATH;
+const originalPathTitle = process.env.Path;
+
+const restoreEnvValue = (key: 'NODE_ENV' | 'PATH' | 'Path', value?: string) => {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+};
+
+afterEach(() => {
+  jest.resetModules();
+  jest.dontMock('noobs');
+  restoreEnvValue('NODE_ENV', originalNodeEnv);
+  restoreEnvValue('PATH', originalPath);
+  restoreEnvValue('Path', originalPathTitle);
+});
+
+test('prepends noobs bin path before loading the native noobs module', () => {
+  const mockNoobs = { Init: jest.fn() };
+  let mockPathWhenNoobsLoaded: string | undefined;
+  let mockPathTitleWhenNoobsLoaded: string | undefined;
+
+  process.env.NODE_ENV = 'test';
+  process.env.PATH = 'C:\\Windows\\System32';
+  process.env.Path = 'C:\\Windows\\System32';
+
+  jest.resetModules();
+  jest.doMock(
+    'noobs',
+    () => {
+      mockPathWhenNoobsLoaded = process.env.PATH;
+      mockPathTitleWhenNoobsLoaded = process.env.Path;
+      return mockNoobs;
+    },
+    { virtual: true },
+  );
+
+  const noobsRuntime = require('../../main/noobsRuntime')
+    .default as typeof mockNoobs;
+  const expectedBinPath = getNoobsBinPath(
+    getNoobsDistPath(path.resolve(__dirname, '../../main'), false),
+  );
+
+  expect(noobsRuntime).toBe(mockNoobs);
+  expect(mockPathWhenNoobsLoaded?.split(path.delimiter)[0]).toBe(
+    expectedBinPath,
+  );
+  expect(mockPathTitleWhenNoobsLoaded).toBe(mockPathWhenNoobsLoaded);
+  expect(mockPathWhenNoobsLoaded?.split(path.delimiter)).toContain(
+    'C:\\Windows\\System32',
+  );
+});

--- a/src/__tests__/main/noobsRuntimePath.test.ts
+++ b/src/__tests__/main/noobsRuntimePath.test.ts
@@ -1,0 +1,88 @@
+import path from 'path';
+import {
+  getNoobsBinPath,
+  getNoobsDistPath,
+  prependPathEntry,
+  setNoobsPathEnvironment,
+} from '../../main/noobsRuntimePath';
+
+test('resolves noobs dist path for development and production bundles', () => {
+  const devBase = path.resolve('C:\\repo\\.erb\\dll');
+  const prodBase = path.resolve('C:\\repo\\release\\app\\dist\\main');
+  const expectedDistPath = path.resolve(
+    'C:\\repo\\release\\app\\node_modules\\noobs\\dist',
+  );
+
+  expect(getNoobsDistPath(devBase, true)).toBe(expectedDistPath);
+  expect(getNoobsDistPath(prodBase, false)).toBe(expectedDistPath);
+});
+
+test('resolves noobs dist path outside app.asar for packaged bundles', () => {
+  const packagedBase = path.resolve(
+    'C:\\Program Files\\WarcraftRecorder\\resources\\app.asar\\dist\\main',
+  );
+
+  expect(getNoobsDistPath(packagedBase, false)).toBe(
+    path.resolve(
+      'C:\\Program Files\\WarcraftRecorder\\resources\\app.asar.unpacked\\node_modules\\noobs\\dist',
+    ),
+  );
+});
+
+test('prepends noobs bin path without duplicating an existing entry', () => {
+  const noobsBinPath = path.resolve(
+    'C:\\repo\\release\\app\\node_modules\\noobs\\dist\\bin',
+  );
+  const systemPath = ['C:\\Windows\\System32', noobsBinPath].join(
+    path.delimiter,
+  );
+
+  expect(prependPathEntry(systemPath, noobsBinPath)).toBe(
+    [noobsBinPath, 'C:\\Windows\\System32'].join(path.delimiter),
+  );
+});
+
+test('removes an existing noobs bin entry regardless of path casing', () => {
+  const noobsBinPath = path.resolve(
+    'C:\\repo\\release\\app\\node_modules\\noobs\\dist\\bin',
+  );
+  const systemPath = [noobsBinPath.toUpperCase(), 'C:\\Windows\\System32'].join(
+    path.delimiter,
+  );
+
+  expect(prependPathEntry(systemPath, noobsBinPath)).toBe(
+    [noobsBinPath, 'C:\\Windows\\System32'].join(path.delimiter),
+  );
+});
+
+test('sets both PATH casings for native OBS dependency lookup', () => {
+  const env: NodeJS.ProcessEnv = {
+    PATH: 'C:\\Windows\\System32',
+  };
+  const distPath = path.resolve(
+    'C:\\repo\\release\\app\\node_modules\\noobs\\dist',
+  );
+
+  setNoobsPathEnvironment(env, distPath);
+
+  expect(env.PATH).toBe(
+    [getNoobsBinPath(distPath), 'C:\\Windows\\System32'].join(path.delimiter),
+  );
+  expect(env.Path).toBe(env.PATH);
+});
+
+test('preserves existing Path value when PATH is absent', () => {
+  const env: NodeJS.ProcessEnv = {
+    Path: 'C:\\Windows\\System32',
+  };
+  const distPath = path.resolve(
+    'C:\\repo\\release\\app\\node_modules\\noobs\\dist',
+  );
+
+  setNoobsPathEnvironment(env, distPath);
+
+  expect(env.PATH).toBe(
+    [getNoobsBinPath(distPath), 'C:\\Windows\\System32'].join(path.delimiter),
+  );
+  expect(env.Path).toBe(env.PATH);
+});

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -52,13 +52,14 @@ import noobs, {
   SceneItemPosition,
   Signal,
   SourceDimensions,
-} from 'noobs';
+} from './noobsRuntime';
 import { getNativeWindowHandle, send } from './main';
 import { ipcMain } from 'electron';
 import Poller from 'utils/Poller';
 import AsyncQueue from 'utils/AsyncQueue';
 import assert from 'assert';
 import { isHighRes } from 'renderer/rendererutils';
+import { getNoobsDistPath } from './noobsRuntimePath';
 
 const devMode = process.env.NODE_ENV === 'development';
 
@@ -1093,12 +1094,9 @@ export default class Recorder extends EventEmitter {
       ? path.resolve(__dirname, './logs')
       : path.resolve(__dirname, '../../dist/main/logs');
 
-    let noobsPath = devMode
-      ? path.resolve(__dirname, '../../release/app/node_modules/noobs/dist')
-      : path.resolve(__dirname, '../../node_modules/noobs/dist');
+    const noobsPath = getNoobsDistPath(__dirname, devMode);
 
     logPath = fixPathWhenPackaged(logPath);
-    noobsPath = fixPathWhenPackaged(noobsPath);
 
     console.info('[Recorder] Noobs path:', noobsPath);
     console.info('[Recorder] Log path:', logPath);

--- a/src/main/noobsRuntime.ts
+++ b/src/main/noobsRuntime.ts
@@ -1,0 +1,14 @@
+import { setNoobsPathEnvironment } from './noobsRuntimePath';
+
+setNoobsPathEnvironment(process.env);
+
+const noobs = require('noobs') as typeof import('noobs');
+
+export type {
+  ObsData,
+  SceneItemPosition,
+  Signal,
+  SourceDimensions,
+} from 'noobs';
+
+export default noobs;

--- a/src/main/noobsRuntimePath.ts
+++ b/src/main/noobsRuntimePath.ts
@@ -1,0 +1,48 @@
+import path from 'path';
+
+const fixPathWhenPackaged = (p: string) =>
+  p.replace('app.asar', 'app.asar.unpacked');
+
+export const getNoobsDistPath = (
+  baseDir = __dirname,
+  devMode = process.env.NODE_ENV === 'development',
+): string => {
+  const distPath = devMode
+    ? path.resolve(baseDir, '../../release/app/node_modules/noobs/dist')
+    : path.resolve(baseDir, '../../node_modules/noobs/dist');
+
+  return fixPathWhenPackaged(distPath);
+};
+
+export const getNoobsBinPath = (distPath: string): string =>
+  path.join(distPath, 'bin');
+
+export const prependPathEntry = (
+  currentPath: string | undefined,
+  entry: string,
+): string => {
+  const normalizedEntry = path.normalize(entry);
+  const entries = (currentPath || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .filter(
+      (item) =>
+        path.normalize(item).toLowerCase() !== normalizedEntry.toLowerCase(),
+    );
+
+  return [normalizedEntry, ...entries].join(path.delimiter);
+};
+
+export const setNoobsPathEnvironment = (
+  env: NodeJS.ProcessEnv,
+  distPath = getNoobsDistPath(),
+) => {
+  const currentPath = env.PATH || env.Path;
+  const pathWithNoobsBin = prependPathEntry(
+    currentPath,
+    getNoobsBinPath(distPath),
+  );
+
+  env.PATH = pathWithNoobsBin;
+  env.Path = pathWithNoobsBin;
+};


### PR DESCRIPTION
﻿## Summary

Fixes #821.

This keeps the chat overlay as an OBS `image_source`, but loads `noobs` through a small runtime wrapper that prepends `noobs/dist/bin` to both `PATH` and `Path` before the native `noobs` module is required. `Recorder` now uses the same noobs dist path resolver for `noobs.Init`, including the packaged `app.asar -> app.asar.unpacked` case.

## Root cause

The failure logs show the default `chat-overlay.png` reaching OBS `image_source`, but OBS fails to decode/load the texture. The bundled `noobs` loader only updates `process.env.Path`, while native dependency lookup around OBS/FFmpeg image loading can depend on the process path casing being available consistently. If the OBS/FFmpeg DLL path is incomplete at native module load time, PNG decoding can fall back to WIC and fail with the reported decoder/texture errors.

## Changes

- Add `noobsRuntimePath` helpers for resolving packaged/dev noobs paths and prepending `noobs/dist/bin` without duplicate entries.
- Add `noobsRuntime` wrapper so the path environment is prepared before `require('noobs')`.
- Use the shared noobs dist resolver in `Recorder.initializeObs()`.
- Add regression tests for `PATH`/`Path`, `app.asar.unpacked`, duplicate path handling, and import-time ordering before native `noobs` load.

## Validation

- `jest --runTestsByPath src/__tests__/main/noobsRuntimePath.test.ts src/__tests__/main/noobsRuntime.test.ts --runInBand --silent --modulePathIgnorePatterns release/app`
- `eslint src/main/Recorder.ts src/main/noobsRuntime.ts src/main/noobsRuntimePath.ts src/__tests__/main/noobsRuntimePath.test.ts src/__tests__/main/noobsRuntime.test.ts`
- `npm run build:main`
- `git diff --check origin/main..HEAD`
- Packaged runtime smoke test with `win-unpacked` build and `chatOverlayEnabled=true`: OBS loaded `image-source.dll`/`obs-ffmpeg.dll`, created `WCR Chat Overlay` as `image_source`, loaded `resources/assets/poster/chat-overlay.png`, and log counts were 0 for `Failed to load texture`, `Failed to load file`, `Failed to find decoder`, and `WIC:`.
