### PR TITLE
Make kill video rendering handle mixed POV sources

### DIFF
--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -478,6 +478,11 @@ export default class VideoProcessQueue {
         const item: UploadQueueItem = { path: videoPath };
         this.queueUpload(item);
       }
+    } catch (error) {
+      console.error(
+        '[VideoProcessQueue] Error processing kill video:',
+        String(error),
+      );
     } finally {
       done();
     }
@@ -855,7 +860,7 @@ export default class VideoProcessQueue {
     const map =
       item.audioTrackIndex === -1
         ? '-map [a]'
-        : `-map ${item.audioTrackIndex}:a`;
+        : `-map ${item.audioTrackIndex}:a?`;
 
     console.info('[VideoProcessQueue] Audio map filter:', map);
     return map;
@@ -874,7 +879,7 @@ export default class VideoProcessQueue {
       const fadeDuration = 1;
       const fadeOutStart = Math.max(0, segmentDuration - fadeDuration);
 
-      const scale = `${item.width}:-2`;
+      const scale = `${item.width}:${item.height}:force_original_aspect_ratio=decrease`;
       const pad = `${item.width}:${item.height}:(ow-iw)/2:(oh-ih)/2`;
 
       const fadeIn = `t=in:st=0:d=${fadeDuration}`;


### PR DESCRIPTION
Refs #812.

## Summary

This PR improves kill video rendering robustness for mixed POV source files:

- maps the selected POV audio stream as optional (`-map X:a?`) so FFmpeg does not fail when that source has no audio stream
- scales each POV into the target canvas with `force_original_aspect_ratio=decrease` before padding
- catches FFmpeg failures inside the kill-video queue worker so they are logged instead of becoming unhandled promise rejections

## Context

The original report does not include full FFmpeg stderr or the reporter's source files, so I cannot confirm this is the exact root cause for #812.

The generated command in the report exposed a couple of fragile FFmpeg assumptions around mixed POV sources and the selected audio stream. This PR addresses those failure modes without changing unrelated video processing behavior.

## Validation

- `npm.cmd run build:main`
- `git diff --check`