### PR TITLE
[codex] Fix PTR recording detection

### DIFF
--- a/src/main/Manager.ts
+++ b/src/main/Manager.ts
@@ -504,7 +504,7 @@ export default class Manager {
     }
 
     if (config.recordClassicPtr) {
-      this.classicLogHandler = new ClassicLogHandler(config.classicPtrLogPath);
+      this.classicPtrLogHandler = new ClassicLogHandler(config.classicPtrLogPath);
     }
 
     if (config.recordEra) {

--- a/src/utils/Poller.ts
+++ b/src/utils/Poller.ts
@@ -109,13 +109,14 @@ export default class Poller extends EventEmitter {
     const { Retail, Classic } = parsed;
 
     const recordRetail = this.cfg.get<boolean>('recordRetail');
+    const recordRetailPtr = this.cfg.get<boolean>('recordRetailPtr');
     const recordClassic = this.cfg.get<boolean>('recordClassic');
+    const recordClassicPtr = this.cfg.get<boolean>('recordClassicPtr');
     const recordEra = this.cfg.get<boolean>('recordEra');
 
     const running =
-      (recordRetail && Retail) ||
-      (recordClassic && Classic) ||
-      (recordEra && Classic); // Era and Classic clients share a process name.
+      ((recordRetail || recordRetailPtr) && Retail) ||
+      ((recordClassic || recordClassicPtr || recordEra) && Classic);
 
     if (this.wowRunning === running) {
       // Nothing to emit.


### PR DESCRIPTION
## Summary

Fix PTR-only recording startup by including the PTR recording flags in process detection.

## Details

- Treat recordRetailPtr as a valid match for the Retail process state emitted by rust-ps.
- Treat recordClassicPtr as a valid match for the Classic process state emitted by rust-ps.
- Store the Classic PTR log handler in classicPtrLogHandler instead of overwriting classicLogHandler.

## Validation

- git show --check --stat --oneline HEAD

No tests were added; this PR intentionally keeps the patch to the minimal runtime fix.