### PR TITLE
Await metadata file writes

### DIFF
--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -300,7 +300,7 @@ const writeMetadataFile = async (videoPath: string, metadata: Metadata) => {
   const metadataFileName = getMetadataFileNameForVideo(videoPath);
   const jsonString = JSON.stringify(metadata, null, 2);
 
-  fspromise.writeFile(metadataFileName, jsonString, {
+  await fspromise.writeFile(metadataFileName, jsonString, {
     encoding: 'utf-8',
   });
 };


### PR DESCRIPTION
## Summary
- Await metadata JSON writes in `writeMetadataFile`.

## Why
`writeMetadataFile` is async and callers already await it, but the internal
`fspromise.writeFile(...)` promise was not awaited. This meant callers could
continue before the metadata file was written, and write failures would not be
propagated through the existing await chain.

## Testing
- `git diff --check`
- Local Jest run with temporary environment mocks: 17/17 passing
- Standard `npm test -- --runInBand` currently fails on existing test setup issues
  unrelated to this change: unresolved tsconfig-style aliases and stale test
  constructor signatures
