### PR TITLE
Prevent native window menu on title bar

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -198,6 +198,9 @@ const createWindow = async () => {
     },
   });
 
+  // Prevent Windows from opening the native window menu on draggable regions.
+  window.on('system-context-menu', (event) => event.preventDefault());
+
   // We need to do this AFTER creating the window as it's used by the preview.
   Recorder.getInstance().initializeObs();
   await manager.startup();


### PR DESCRIPTION
## Summary

Prevent Windows from opening the native system window menu when right-clicking draggable title bar regions in the frameless Electron window.

Fixes #682

## Why

Electron treats `-webkit-app-region: drag` areas as non-client frame regions on Windows, so a right-click can trigger the native system menu. Handling `system-context-menu` in the main process suppresses that menu at the source.

## Validation

- `npx.cmd eslint src/main/main.ts`
- `npm.cmd run prestart`
- Manual GUI check on the actual local app: started the Electron app, right-clicked the title bar, and confirmed no native popup menu was created (`PopupMenusAfter: 0`).