### PR TITLE
[codex] Fix iOS share link clipboard copy

### DIFF
--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -62,6 +62,7 @@ import CloudOffIcon from '@mui/icons-material/CloudOff';
 import Separator from './components/Separator/Separator';
 import { toast } from './components/Toast/useToast';
 import { Phrase } from 'localisation/phrases';
+import { copyTextPromiseToClipboard } from './clipboard';
 
 interface IProps {
   videos: RendererVideo[];
@@ -1041,7 +1042,18 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     if (!cloudVideo) return;
 
     try {
-      await ipc.invoke('getShareableLink', [cloudVideo.videoName]);
+      const shareableLinkPromise = ipc.invoke('getShareableLink', [
+        cloudVideo.videoName,
+      ]) as Promise<string>;
+
+      // Do not await the link before starting the clipboard write. iOS Safari
+      // requires the write call to begin in the original click handler.
+      await copyTextPromiseToClipboard(shareableLinkPromise).catch(async () => {
+        // The main process also writes this link to the clipboard in Electron.
+        // If the browser clipboard path is unavailable, keep desktop behavior.
+        await shareableLinkPromise;
+      });
+
       toast({
         title: getLocalePhrase(appState.language, Phrase.ShareableLinkTitle),
         description: getLocalePhrase(

--- a/src/renderer/clipboard.ts
+++ b/src/renderer/clipboard.ts
@@ -1,0 +1,35 @@
+type ClipboardLike = {
+  write?: (data: ClipboardItem[]) => Promise<void>;
+  writeText: (text: string) => Promise<void>;
+};
+
+type ClipboardItemConstructor = new (
+  items: Record<string, Blob | Promise<Blob>>,
+) => ClipboardItem;
+
+/**
+ * Safari/WebKit rejects clipboard writes if they happen after the click
+ * handler has awaited async work. Passing a Promise-backed ClipboardItem lets
+ * us start the write during the user gesture while the link is still loading.
+ */
+export async function copyTextPromiseToClipboard(
+  textPromise: Promise<string>,
+  clipboard: ClipboardLike = navigator.clipboard,
+  ClipboardItemCtor:
+    | ClipboardItemConstructor
+    | undefined = globalThis.ClipboardItem,
+) {
+  if (clipboard.write && ClipboardItemCtor) {
+    // Keep this promise lazy so clipboard.write is called synchronously.
+    const textBlobPromise = textPromise.then(
+      (text) => new Blob([text], { type: 'text/plain' }),
+    );
+
+    await clipboard.write([
+      new ClipboardItemCtor({ 'text/plain': textBlobPromise }),
+    ]);
+    return;
+  }
+
+  await clipboard.writeText(await textPromise);
+}

--- a/src/storage/CloudClient.ts
+++ b/src/storage/CloudClient.ts
@@ -1212,6 +1212,7 @@ export default class CloudClient implements StorageClient {
       const videoName = args[0];
       const shareable = await this.getShareableLink(videoName);
       clipboard.writeText(shareable);
+      return shareable;
     });
 
     ipcMain.on('deleteVideosCloud', async (_event, args) => {


### PR DESCRIPTION
## Summary
- Add a renderer clipboard helper that starts Clipboard API writes synchronously using a Promise-backed `ClipboardItem`.
- Update the share-link button flow to pass the pending link promise to the clipboard helper instead of awaiting it first.
- Return the generated shareable link from the Electron `getShareableLink` IPC handler while preserving the existing Electron clipboard write fallback.

## Root Cause
On iOS Safari/WebKit, `navigator.clipboard.writeText()` can be rejected when it runs after awaited async work because the original user activation has been lost.

## Related Issue
- https://github.com/aza547/wow-recorder/issues/794

## Validation
- `eslint` on the changed production files
- `npm run build:renderer`

## Notes
- No automated regression test is included in this PR.
- Manual verification on iOS Safari is still needed before opening a PR to the upstream repository.
