### PR TITLE
[codex] Handle delayed OBS stop recovery

### DIFF
--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -1000,8 +1000,8 @@ export default class Recorder extends EventEmitter {
     }
 
     this.stopQueue.empty();
-    noobs.StopRecording();
     const wrote = this.stopQueue.shift();
+    noobs.StopRecording();
 
     try {
       await Promise.race([wrote, getPromiseBomb(60, 'Failed to stop')]);
@@ -1017,7 +1017,7 @@ export default class Recorder extends EventEmitter {
 
       await Promise.race([
         wrote,
-        getPromiseBomb(3, 'Failed to recover by force stopping'),
+        getPromiseBomb(60, 'Failed to recover by force stopping'),
       ]);
 
       console.info('[Recorder] Force stopped successfully');


### PR DESCRIPTION
## Summary

This makes OBS stop recovery less brittle when OBS emits `stop` quickly but takes longer to fully deactivate/finalize the output.

In the observed failure mode, WCR timed out during the normal stop path, called `ForceStopRecording()`, then only waited 3 seconds for recovery. OBS can still be finalizing at that point, so WCR may discard a recording even though a later `deactivate` signal would have completed the stop.

## Changes

- Create the stop wait promise before calling `StopRecording()`.
- Increase the forced-stop recovery wait from 3 seconds to 60 seconds.
- Keep the change scoped to `Recorder.ts`.

## Validation

- `npm run build`
- `npx eslint src/main/Recorder.ts --no-warn-ignored`
- Real dev app smoke test with Retail WoW running: WCR detected WoW, started the buffer, recorded a simulated Retail Solo Shuffle, stopped OBS cleanly, processed the MP4, wrote metadata, and did not queue cloud upload.
