### PR TITLE
[codex] Add clip source navigation

### DIFF
--- a/src/localisation/chineseSimplified.ts
+++ b/src/localisation/chineseSimplified.ts
@@ -220,6 +220,8 @@ const CHINESE_SIMPLIFIED: Translations = {
   [Phrase.PlaybackSpeedTooltip]: '回放速度',
   [Phrase.ClipTooltip]: '剪辑',
   [Phrase.ClipUnavailableTooltip]: '只能剪辑本地保存的视频',
+  [Phrase.ClipSourceTooltip]: '转到源录制',
+  [Phrase.ClipSourceUnavailableTooltip]: '源录制不可用',
   [Phrase.ConfirmTooltip]: '确认',
   [Phrase.CancelTooltip]: '取消',
   [Phrase.TagButtonTooltip]: '添加标签',

--- a/src/localisation/english.ts
+++ b/src/localisation/english.ts
@@ -225,6 +225,8 @@ const ENGLISH: Translations = {
   [Phrase.PlaybackSpeedTooltip]: 'Playback Speed',
   [Phrase.ClipTooltip]: 'Clip',
   [Phrase.ClipUnavailableTooltip]: 'You can only clip locally saved videos, while in single player mode',
+  [Phrase.ClipSourceTooltip]: 'Go to source recording',
+  [Phrase.ClipSourceUnavailableTooltip]: 'Source recording unavailable',
   [Phrase.ConfirmTooltip]: 'Confirm',
   [Phrase.CancelTooltip]: 'Cancel',
   [Phrase.TagButtonTooltip]: 'Add a custom tag.',

--- a/src/localisation/german.ts
+++ b/src/localisation/german.ts
@@ -220,6 +220,8 @@ const GERMAN: Translations = {
   [Phrase.PlaybackSpeedTooltip]: 'Wiedergabegeschwindigkeit',
   [Phrase.ClipTooltip]: 'Clip',
   [Phrase.ClipUnavailableTooltip]: 'Du kannst nur lokal gespeicherte Videos clipen',
+  [Phrase.ClipSourceTooltip]: 'Zur Quellaufnahme wechseln',
+  [Phrase.ClipSourceUnavailableTooltip]: 'Quellaufnahme nicht verfügbar',
   [Phrase.ConfirmTooltip]: 'Bestätigen',
   [Phrase.CancelTooltip]: 'Abbrechen',
   [Phrase.TagButtonTooltip]: 'Einen Tag hinzufügen',

--- a/src/localisation/korean.ts
+++ b/src/localisation/korean.ts
@@ -220,6 +220,8 @@ const KOREAN: Translations = {
   [Phrase.PlaybackSpeedTooltip]: '재생 속도',
   [Phrase.ClipTooltip]: '클립',
   [Phrase.ClipUnavailableTooltip]: '디스크에 저장된 동영상만 클립할 수 있습니다.',
+  [Phrase.ClipSourceTooltip]: '원본 녹화로 이동',
+  [Phrase.ClipSourceUnavailableTooltip]: '원본 녹화를 사용할 수 없습니다',
   [Phrase.ConfirmTooltip]: '확인',
   [Phrase.CancelTooltip]: '취소',
   [Phrase.TagButtonTooltip]: '태그',

--- a/src/localisation/phrases.ts
+++ b/src/localisation/phrases.ts
@@ -225,6 +225,8 @@ enum Phrase {
   PlaybackSpeedTooltip,
   ClipTooltip,
   ClipUnavailableTooltip,
+  ClipSourceTooltip,
+  ClipSourceUnavailableTooltip,
   ConfirmTooltip,
   CancelTooltip,
   TagButtonTooltip,

--- a/src/main/Manager.ts
+++ b/src/main/Manager.ts
@@ -6,7 +6,6 @@ import {
   buildClipMetadata,
   checkAdvancedCombatLogging,
   getConfigWtfPath,
-  getMetadataForVideo,
   getOBSFormattedDate,
   isManualRecordHotKey,
   nextKeyPressPromise,
@@ -38,7 +37,7 @@ import {
   getBaseConfig,
   validateBaseConfig,
 } from '../utils/configUtils';
-import { ERecordingState, QualityPresets } from './obsEnums';
+import { ERecordingState } from './obsEnums';
 import {
   runClassicRecordingTest,
   runRetailRecordingTest,
@@ -504,7 +503,9 @@ export default class Manager {
     }
 
     if (config.recordClassicPtr) {
-      this.classicPtrLogHandler = new ClassicLogHandler(config.classicPtrLogPath);
+      this.classicPtrLogHandler = new ClassicLogHandler(
+        config.classicPtrLogPath,
+      );
     }
 
     if (config.recordEra) {
@@ -591,7 +592,13 @@ export default class Manager {
 
         const sourceMetadata = rendererVideoToMetadata({ ...video });
         const now = new Date();
-        const clipMetadata = buildClipMetadata(sourceMetadata, duration, now);
+        const clipMetadata = buildClipMetadata(
+          sourceMetadata,
+          duration,
+          now,
+          offset,
+          video.videoName,
+        );
 
         const clipQueueItem: VideoQueueItem = {
           name: video.videoName,

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -430,7 +430,7 @@ export default class Recorder extends EventEmitter {
    * misbehaves.
    */
   public async startRecording(offset: number) {
-    console.info('[Recorder] Queued start recording');
+    console.info('[Recorder] Queued convert buffer');
     const { resolveHelper, rejectHelper, promise } = deferredPromiseHelper();
 
     const task = async () => {
@@ -438,7 +438,7 @@ export default class Recorder extends EventEmitter {
         await this.convertObsBuffer(offset);
         resolveHelper(null);
       } catch (error) {
-        console.error('[Recorder] Error on starting recording', String(error));
+        console.error('[Recorder] Error on converting buffer', String(error));
         emitErrorReport(error);
         rejectHelper(error);
       }
@@ -962,7 +962,7 @@ export default class Recorder extends EventEmitter {
   }
 
   /**
-   * Conver the buffer recording to a a real recording.
+   * Convert the buffer recording to a real recording.
    */
   private async convertObsBuffer(offset: number) {
     console.info('[Recorder] Convert buffer with offset:', offset);

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -37,13 +37,19 @@ const isDebug = devMode || process.env.DEBUG_PROD === 'true';
 // Use the dynamically linked ffmpeg.exe we package with OBS in noobs. This
 // allows us to avoid including a static ffmpeg.exe which is an extra 60MB.
 const ffmpegPathRel = 'node_modules/noobs/dist/bin/ffmpeg.exe';
+const ffprobePathRel = 'node_modules/noobs/dist/bin/ffprobe.exe';
 
 let ffmpegPathAbs = devMode
   ? path.resolve(__dirname, '../../release/app/', ffmpegPathRel)
   : path.resolve(__dirname, '../../', ffmpegPathRel);
+let ffprobePathAbs = devMode
+  ? path.resolve(__dirname, '../../release/app/', ffprobePathRel)
+  : path.resolve(__dirname, '../../', ffprobePathRel);
 
 ffmpegPathAbs = fixPathWhenPackaged(ffmpegPathAbs);
+ffprobePathAbs = fixPathWhenPackaged(ffprobePathAbs);
 ffmpeg.setFfmpegPath(ffmpegPathAbs);
+ffmpeg.setFfprobePath(ffprobePathAbs);
 
 /**
  * A queue for cutting videos to size.
@@ -264,6 +270,7 @@ export default class VideoProcessQueue {
       // covers the cases where we're cutting a section off the end of
       // the video due to a timeout.
       const videoPath = await this.cutVideo(data, outputDir);
+      await VideoProcessQueue.updateClipTimingMetadata(data, videoPath);
 
       // Add the size of the newly cut video. We can't do this earlier
       // as the size will change when we cut/remux.
@@ -754,6 +761,73 @@ export default class VideoProcessQueue {
     await VideoProcessQueue.ffmpegWrapper(fn, 'Video cut');
     console.timeEnd('[VideoProcessQueue] Video cut took:');
     return outputPath;
+  }
+
+  private static async getVideoDurationSeconds(
+    videoPath: string,
+  ): Promise<number | undefined> {
+    return new Promise((resolve) => {
+      ffmpeg.ffprobe(videoPath, (error, data) => {
+        if (error) {
+          console.warn(
+            '[VideoProcessQueue] Failed to probe video duration',
+            videoPath,
+            String(error),
+          );
+          resolve(undefined);
+          return;
+        }
+
+        const duration = data.format.duration;
+        resolve(
+          Number.isFinite(duration) && duration > 0 ? duration : undefined,
+        );
+      });
+    });
+  }
+
+  private static async updateClipTimingMetadata(
+    data: VideoQueueItem,
+    videoPath: string,
+  ) {
+    if (!data.clip) return;
+
+    const actualDuration =
+      await VideoProcessQueue.getVideoDurationSeconds(videoPath);
+    if (!actualDuration) return;
+
+    data.metadata.duration = actualDuration;
+
+    const parentOffset = data.metadata.parentOffset;
+    if (typeof parentOffset !== 'number' || !Number.isFinite(parentOffset)) {
+      return;
+    }
+
+    const requestedDuration = data.duration;
+    if (!Number.isFinite(requestedDuration) || requestedDuration <= 0) {
+      return;
+    }
+
+    // Copy-based clipping can only start on a keyframe, so ffmpeg may include
+    // frames from before the requested offset. Match source navigation to the
+    // clip that was actually written, not just the requested slider position.
+    const keyframeLeadIn = Math.min(
+      parentOffset,
+      Math.max(0, actualDuration - requestedDuration),
+    );
+
+    if (keyframeLeadIn <= 0) return;
+
+    const adjustedParentOffset = parentOffset - keyframeLeadIn;
+    data.metadata.parentOffset = Math.round(adjustedParentOffset * 1000) / 1000;
+
+    console.info('[VideoProcessQueue] Adjusted clip source offset:', {
+      requestedOffset: parentOffset,
+      adjustedOffset: data.metadata.parentOffset,
+      requestedDuration,
+      actualDuration,
+      keyframeLeadIn,
+    });
   }
 
   /**

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -192,6 +192,8 @@ type VideoQueueItem = {
 type Metadata = {
   category: VideoCategory;
   parentCategory?: VideoCategory; // present if it's a clip
+  parentVideoName?: string; // present if a clip knows its source video
+  parentOffset?: number; // seconds into the source video where the clip starts
   duration: number;
   start?: number; // epoch start time of activity
   clippedAt?: number; // epoch time of clipping

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -627,10 +627,20 @@ const getPromiseBomb = (fuse: number, reason: string) => {
   });
 };
 
-const buildClipMetadata = (initial: Metadata, duration: number, date: Date) => {
+const buildClipMetadata = (
+  initial: Metadata,
+  duration: number,
+  date: Date,
+  offset: number,
+  parentVideoName?: string,
+) => {
   const final = initial;
   final.duration = duration;
+  // Most clip metadata is copied from the source recording; parent-prefixed
+  // fields are the trusted source navigation data added at clipping time.
   final.parentCategory = initial.category;
+  final.parentVideoName = parentVideoName;
+  final.parentOffset = offset;
   final.category = VideoCategory.Clips;
   final.protected = true;
   final.clippedAt = date.getTime();

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -640,7 +640,7 @@ const buildClipMetadata = (
   // fields are the trusted source navigation data added at clipping time.
   final.parentCategory = initial.category;
   final.parentVideoName = parentVideoName;
-  final.parentOffset = offset;
+  final.parentOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
   final.category = VideoCategory.Clips;
   final.protected = true;
   final.clippedAt = date.getTime();

--- a/src/parsing/LogHandler.ts
+++ b/src/parsing/LogHandler.ts
@@ -217,9 +217,7 @@ export default abstract class LogHandler {
       return;
     }
 
-    console.info(
-      `[LogHandler] Start recording a video for category: ${category}`,
-    );
+    console.info(`[LogHandler] Start an activity for category: ${category}`);
 
     // Offset is the number of seconds to cut back into the buffer. That way
     // the buffer length is irrelevant. It is physically impossible to have

--- a/src/renderer/CategoryPage.tsx
+++ b/src/renderer/CategoryPage.tsx
@@ -50,7 +50,7 @@ import { Phrase } from 'localisation/phrases';
 import BulkTransferDialog from './BulkTransferDialog';
 import VideoChat from './VideoChat';
 import ConfirmChatNamePrompt from './ConfirmChatNamePrompt';
-import { findClipParent } from './ClipParent';
+import { findClipParent, getClipParentOffset } from './ClipParent';
 
 interface IProps {
   category: VideoCategory;
@@ -117,7 +117,7 @@ const CategoryPage = (props: IProps) => {
     if (!parent) return;
 
     // Start source playback at the offset captured when the clip was created.
-    persistentProgress.current = clip.parentOffset ?? 0;
+    persistentProgress.current = getClipParentOffset(clip);
 
     setAppState((prevState) => ({
       ...prevState,

--- a/src/renderer/CategoryPage.tsx
+++ b/src/renderer/CategoryPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AppState, RendererVideo } from 'main/types';
+import { AppState, RendererVideo, StorageFilter } from 'main/types';
 import {
   Dispatch,
   RefObject,
@@ -50,6 +50,7 @@ import { Phrase } from 'localisation/phrases';
 import BulkTransferDialog from './BulkTransferDialog';
 import VideoChat from './VideoChat';
 import ConfirmChatNamePrompt from './ConfirmChatNamePrompt';
+import { findClipParent } from './ClipParent';
 
 interface IProps {
   category: VideoCategory;
@@ -108,8 +109,40 @@ const CategoryPage = (props: IProps) => {
     return correlatedState.filter(queryFilter);
   }, [correlatedState, dateRangeFilter, videoFilterTags, language]);
 
+  const getClipParent = (clip: RendererVideo) =>
+    findClipParent(clip, videoState);
+
+  const goToClipParent = (clip: RendererVideo) => {
+    const parent = getClipParent(clip);
+    if (!parent) return;
+
+    // Start source playback at the offset captured when the clip was created.
+    persistentProgress.current = clip.parentOffset ?? 0;
+
+    setAppState((prevState) => ({
+      ...prevState,
+      category: parent.category,
+      selectedVideos: [parent],
+      multiPlayerMode: false,
+      playing: false,
+      videoFilterTags: [],
+      dateRangeFilter: {
+        startDate: null,
+        endDate: null,
+      },
+      // The source may be hidden by the Clips view's current storage filter.
+      storageFilter: StorageFilter.BOTH,
+    }));
+  };
+
   // The data backing the video selection table.
-  const table = useTable(filteredState, appState, setVideoState);
+  const table = useTable(
+    filteredState,
+    appState,
+    setVideoState,
+    getClipParent,
+    goToClipParent,
+  );
 
   const haveVideos = categoryState.length > 0;
   const isClips = category === VideoCategory.Clips;

--- a/src/renderer/ClipParent.ts
+++ b/src/renderer/ClipParent.ts
@@ -1,0 +1,151 @@
+import { RendererVideo } from '../main/types';
+import { VideoCategory } from '../types/VideoCategory';
+import { areDatesWithinSeconds } from './rendererutils';
+
+const sourceStartTimeToleranceSeconds = 60;
+const clippedAtSuffixPattern = /\s+-\s+Clipped At\s+.+$/i;
+const videoFileExtensionPattern = /\.(m4v|mkv|mov|mp4|webm)$/i;
+
+const normalizeParentVideoName = (videoName: string) => {
+  // Clip metadata can come from old builds or hand-edited files where the
+  // source was stored as a path, while renderer videos use extensionless names.
+  const fileName = videoName.trim().split(/[\\/]/).pop() ?? videoName;
+  return fileName.replace(videoFileExtensionPattern, '');
+};
+
+const getLegacyParentVideoName = (clip: RendererVideo) => {
+  const clipVideoName = normalizeParentVideoName(clip.videoName);
+  const parentVideoName = clipVideoName.replace(clippedAtSuffixPattern, '');
+
+  return parentVideoName === clipVideoName ? undefined : parentVideoName;
+};
+
+const getVideoStartTime = (video: RendererVideo) => {
+  if (!video.start) return undefined;
+
+  const startTime = new Date(video.start).getTime();
+  if (Number.isNaN(startTime)) return undefined;
+
+  return startTime;
+};
+
+const getStoragePriority = (clip: RendererVideo, candidate: RendererVideo) => {
+  if (candidate.cloud === clip.cloud) return 0;
+  return candidate.cloud ? 2 : 1;
+};
+
+const compareStableParentOrder = (
+  clip: RendererVideo,
+  first: RendererVideo,
+  second: RendererVideo,
+) =>
+  getStoragePriority(clip, first) - getStoragePriority(clip, second) ||
+  first.videoName.localeCompare(second.videoName);
+
+const canBeClipParent = (clip: RendererVideo, candidate: RendererVideo) => {
+  if (candidate.category === VideoCategory.Clips) return false;
+  if (candidate.category !== clip.parentCategory) return false;
+  return true;
+};
+
+const findClipParent = (
+  clip: RendererVideo,
+  videos: RendererVideo[],
+): RendererVideo | undefined => {
+  if (clip.category !== VideoCategory.Clips || !clip.parentCategory) {
+    return undefined;
+  }
+
+  if (clip.parentVideoName) {
+    const parentVideoName = normalizeParentVideoName(clip.parentVideoName);
+    const exactParent = videos
+      .filter(
+        (candidate) =>
+          parentVideoName &&
+          normalizeParentVideoName(candidate.videoName) === parentVideoName &&
+          canBeClipParent(clip, candidate),
+      )
+      .sort((first, second) =>
+        compareStableParentOrder(clip, first, second),
+      )[0];
+
+    if (exactParent) return exactParent;
+    if (parentVideoName) {
+      // Explicit source metadata means a missing match should disable the
+      // action instead of guessing a different recording from the same pull.
+      return undefined;
+    }
+  }
+
+  const legacyParentVideoName = getLegacyParentVideoName(clip);
+  if (legacyParentVideoName) {
+    // Existing clips did not persist parentVideoName, but their filename keeps
+    // the source recording name before the " - Clipped at ..." suffix.
+    const legacyParent = videos
+      .filter(
+        (candidate) =>
+          normalizeParentVideoName(candidate.videoName) ===
+            legacyParentVideoName && canBeClipParent(clip, candidate),
+      )
+      .sort((first, second) =>
+        compareStableParentOrder(clip, first, second),
+      )[0];
+
+    if (legacyParent) return legacyParent;
+  }
+
+  if (!clip.uniqueHash) {
+    return undefined;
+  }
+
+  const clipStart = getVideoStartTime(clip);
+  if (clipStart === undefined) {
+    return undefined;
+  }
+
+  // Hash and start time are only a legacy fallback, so score all matching
+  // candidates first instead of letting array order decide between duplicates.
+  const fallbackParents = videos
+    .map((candidate) => {
+      if (!canBeClipParent(clip, candidate)) return undefined;
+      if (!candidate.uniqueHash) return undefined;
+      if (candidate.uniqueHash !== clip.uniqueHash) return undefined;
+
+      const candidateStart = getVideoStartTime(candidate);
+      if (candidateStart === undefined) return undefined;
+
+      if (
+        !areDatesWithinSeconds(
+          new Date(candidateStart),
+          new Date(clipStart),
+          sourceStartTimeToleranceSeconds,
+        )
+      ) {
+        return undefined;
+      }
+
+      return {
+        candidate,
+        startDeltaMs: Math.abs(candidateStart - clipStart),
+      };
+    })
+    .filter(
+      (
+        fallbackParent,
+      ): fallbackParent is {
+        candidate: RendererVideo;
+        startDeltaMs: number;
+      } => fallbackParent !== undefined,
+    )
+    .sort(
+      (first, second) =>
+        getStoragePriority(clip, first.candidate) -
+          getStoragePriority(clip, second.candidate) ||
+        first.startDeltaMs - second.startDeltaMs ||
+        first.candidate.videoName.localeCompare(second.candidate.videoName),
+    );
+
+  return fallbackParents[0]?.candidate;
+};
+
+export { findClipParent };

--- a/src/renderer/ClipParent.ts
+++ b/src/renderer/ClipParent.ts
@@ -20,6 +20,16 @@ const getLegacyParentVideoName = (clip: RendererVideo) => {
   return parentVideoName === clipVideoName ? undefined : parentVideoName;
 };
 
+const getClipParentOffset = (clip: RendererVideo) => {
+  const offset = clip.parentOffset;
+
+  if (offset === undefined || !Number.isFinite(offset) || offset < 0) {
+    return 0;
+  }
+
+  return offset;
+};
+
 const getVideoStartTime = (video: RendererVideo) => {
   if (!video.start) return undefined;
 
@@ -94,6 +104,12 @@ const findClipParent = (
     if (legacyParent) return legacyParent;
   }
 
+  if (!clip.parentVideoName && !legacyParentVideoName) {
+    // Generated clips, such as kill videos, can share the source uniqueHash but
+    // do not have a single trusted source recording or offset to jump to.
+    return undefined;
+  }
+
   if (!clip.uniqueHash) {
     return undefined;
   }
@@ -148,4 +164,4 @@ const findClipParent = (
   return fallbackParents[0]?.candidate;
 };
 
-export { findClipParent };
+export { findClipParent, getClipParentOffset };

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -179,6 +179,15 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   // We show a progress spinner until the video is ready to play.
   const [spinner, setSpinner] = useState<boolean>(true);
 
+  // Capture the requested starting point for this player instance. This is
+  // used when jumping from a clip to its source, where URL fragments alone are
+  // not reliable enough to seek the custom vod:// source.
+  const initialSeek = useRef<number>(persistentProgress.current);
+  const initialSeekApplied = useRef<boolean>(
+    !Number.isFinite(persistentProgress.current) ||
+      persistentProgress.current <= 0,
+  );
+
   // On the initial seek we will attempt to resume playback from the
   // persistentProgress prop. The ideas is that when switching between
   // different POVs of the same activity we want to play from the same
@@ -516,13 +525,35 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     progressBarSyncRef.current = null;
   };
 
+  const applyInitialSeek = () => {
+    if (initialSeekApplied.current || !player1.current) {
+      return false;
+    }
+
+    const maxSeek = player1.current.duration;
+    if (!Number.isFinite(maxSeek) || maxSeek <= 0) {
+      return false;
+    }
+
+    const seconds = Math.min(Math.max(0, initialSeek.current), maxSeek);
+    player1.current.currentTime = seconds;
+    persistentProgress.current = seconds;
+    setProgress(seconds);
+    initialSeekApplied.current = true;
+    return true;
+  };
+
   const onDurationChange = () => {
     if (!player1.current || Number.isNaN(player1.current.duration)) {
       return;
     }
 
-    persistentProgress.current = player1.current.currentTime;
+    const didSeek = applyInitialSeek();
     setDuration(player1.current.duration);
+
+    if (!didSeek) {
+      persistentProgress.current = player1.current.currentTime;
+    }
   };
 
   // By default the window hijacks media keys even when

--- a/src/renderer/components/Menu/Menu.tsx
+++ b/src/renderer/components/Menu/Menu.tsx
@@ -45,11 +45,10 @@ export const Menu = ({
     onChange(newValue);
   };
 
-  // This is a bit of a janky way to handle it I guess, but it accounts for
-  // the fact that the two sections of content and settings are two different menus
-  // so when one gets selected, the other needs to be cleared
+  // Keep the highlighted item in sync when navigation is driven from outside
+  // the menu, such as jumping from a clip to its source recording.
   React.useEffect(() => {
-    if (!initialValue) setCurrentValue(undefined);
+    setCurrentValue(initialValue || undefined);
   }, [initialValue]);
 
   return (

--- a/src/renderer/components/Tables/Cells.tsx
+++ b/src/renderer/components/Tables/Cells.tsx
@@ -28,12 +28,14 @@ import {
   LockOpen,
   MessageSquare,
   MessageSquareMore,
+  ExternalLink,
 } from 'lucide-react';
 import { Dispatch, SetStateAction } from 'react';
 import { dungeonAffixesById } from 'main/constants';
 import TagDialog from 'renderer/TagDialog';
 import KillVideoDialog from 'renderer/KillVideoDialog';
 import wcrIcon from '../../../../assets/icon/small-icon.png';
+import { VideoCategory } from 'types/VideoCategory';
 
 const ipc = window.electron.ipcRenderer;
 
@@ -103,6 +105,8 @@ export const populateDetailsCell = (
   language: Language,
   cloudStatus: CloudStatus,
   setVideoState: Dispatch<SetStateAction<RendererVideo[]>>,
+  getClipParent?: (clip: RendererVideo) => RendererVideo | undefined,
+  goToClipParent?: (clip: RendererVideo) => void,
 ) => {
   const video = ctx.getValue() as RendererVideo;
   const { write, del } = cloudStatus;
@@ -214,10 +218,47 @@ export const populateDetailsCell = (
     );
   };
 
+  const renderSourceIcon = () => {
+    if (
+      video.category !== VideoCategory.Clips ||
+      !getClipParent ||
+      !goToClipParent
+    ) {
+      return <></>;
+    }
+
+    const parent = getClipParent(video);
+    const disabled = parent === undefined;
+    const tooltip = disabled
+      ? getLocalePhrase(language, Phrase.ClipSourceUnavailableTooltip)
+      : getLocalePhrase(language, Phrase.ClipSourceTooltip);
+
+    const goToSource = (e: React.MouseEvent<HTMLButtonElement>) => {
+      stopPropagation(e);
+      goToClipParent(video);
+    };
+
+    return (
+      <Tooltip content={tooltip}>
+        <div>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={goToSource}
+            disabled={disabled}
+          >
+            <ExternalLink size={18} />
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  };
+
   return (
     <Box className="inline-flex">
       {renderProtectedIcon()}
       {renderTagIcon()}
+      {renderSourceIcon()}
     </Box>
   );
 };

--- a/src/renderer/components/Tables/Cells.tsx
+++ b/src/renderer/components/Tables/Cells.tsx
@@ -35,7 +35,6 @@ import { dungeonAffixesById } from 'main/constants';
 import TagDialog from 'renderer/TagDialog';
 import KillVideoDialog from 'renderer/KillVideoDialog';
 import wcrIcon from '../../../../assets/icon/small-icon.png';
-import { VideoCategory } from 'types/VideoCategory';
 
 const ipc = window.electron.ipcRenderer;
 
@@ -105,8 +104,6 @@ export const populateDetailsCell = (
   language: Language,
   cloudStatus: CloudStatus,
   setVideoState: Dispatch<SetStateAction<RendererVideo[]>>,
-  getClipParent?: (clip: RendererVideo) => RendererVideo | undefined,
-  goToClipParent?: (clip: RendererVideo) => void,
 ) => {
   const video = ctx.getValue() as RendererVideo;
   const { write, del } = cloudStatus;
@@ -218,29 +215,36 @@ export const populateDetailsCell = (
     );
   };
 
-  const renderSourceIcon = () => {
-    if (
-      video.category !== VideoCategory.Clips ||
-      !getClipParent ||
-      !goToClipParent
-    ) {
-      return <></>;
-    }
+  return (
+    <Box className="inline-flex">
+      {renderProtectedIcon()}
+      {renderTagIcon()}
+    </Box>
+  );
+};
 
-    const parent = getClipParent(video);
-    const disabled = parent === undefined;
-    const tooltip = disabled
-      ? getLocalePhrase(language, Phrase.ClipSourceUnavailableTooltip)
-      : getLocalePhrase(language, Phrase.ClipSourceTooltip);
+export const populateSourceCell = (
+  ctx: CellContext<RendererVideo, unknown>,
+  language: Language,
+  getClipParent: (clip: RendererVideo) => RendererVideo | undefined,
+  goToClipParent: (clip: RendererVideo) => void,
+) => {
+  const video = ctx.getValue() as RendererVideo;
+  const parent = getClipParent(video);
+  const disabled = parent === undefined;
+  const tooltip = disabled
+    ? getLocalePhrase(language, Phrase.ClipSourceUnavailableTooltip)
+    : getLocalePhrase(language, Phrase.ClipSourceTooltip);
 
-    const goToSource = (e: React.MouseEvent<HTMLButtonElement>) => {
-      stopPropagation(e);
-      goToClipParent(video);
-    };
+  const goToSource = (e: React.MouseEvent<HTMLButtonElement>) => {
+    stopPropagation(e);
+    goToClipParent(video);
+  };
 
-    return (
+  return (
+    <Box className="inline-flex">
       <Tooltip content={tooltip}>
-        <div>
+        <div onClick={stopPropagation}>
           <Button
             variant="ghost"
             size="xs"
@@ -251,14 +255,6 @@ export const populateDetailsCell = (
           </Button>
         </div>
       </Tooltip>
-    );
-  };
-
-  return (
-    <Box className="inline-flex">
-      {renderProtectedIcon()}
-      {renderTagIcon()}
-      {renderSourceIcon()}
     </Box>
   );
 };

--- a/src/renderer/components/Tables/TableData.tsx
+++ b/src/renderer/components/Tables/TableData.tsx
@@ -27,6 +27,7 @@ import {
   populateActivityCell,
   populateAffixesCell,
   populateCreatorCell,
+  populateSourceCell,
 } from './Cells';
 import {
   EncounterHeader,
@@ -347,19 +348,12 @@ const useTable = (
     () => [
       {
         id: 'Details',
-        size: 120,
+        size: 80,
         accessorFn: (v) => v,
         sortingFn: (a, b) => detailSort(a, b),
         header: DetailsHeader,
         cell: (ctx) =>
-          populateDetailsCell(
-            ctx,
-            language,
-            cloudStatus,
-            setVideoState,
-            getClipParent,
-            goToClipParent,
-          ),
+          populateDetailsCell(ctx, language, cloudStatus, setVideoState),
       },
       {
         id: 'Type',
@@ -397,6 +391,15 @@ const useTable = (
         header: () => ViewpointsHeader(language),
         cell: (v) => populateViewpointCell(v),
         sortingFn: viewPointCountSort,
+      },
+      {
+        id: 'Source',
+        size: 50,
+        accessorFn: (v) => v,
+        enableSorting: false,
+        header: DetailsHeader,
+        cell: (ctx) =>
+          populateSourceCell(ctx, language, getClipParent, goToClipParent),
       },
     ],
     [appState, setVideoState, getClipParent, goToClipParent],

--- a/src/renderer/components/Tables/TableData.tsx
+++ b/src/renderer/components/Tables/TableData.tsx
@@ -58,6 +58,8 @@ const useTable = (
   videoState: RendererVideo[],
   appState: AppState,
   setVideoState: Dispatch<SetStateAction<RendererVideo[]>>,
+  getClipParent: (clip: RendererVideo) => RendererVideo | undefined,
+  goToClipParent: (clip: RendererVideo) => void,
 ) => {
   const {
     category,
@@ -345,12 +347,19 @@ const useTable = (
     () => [
       {
         id: 'Details',
-        size: 80,
+        size: 120,
         accessorFn: (v) => v,
         sortingFn: (a, b) => detailSort(a, b),
         header: DetailsHeader,
         cell: (ctx) =>
-          populateDetailsCell(ctx, language, cloudStatus, setVideoState),
+          populateDetailsCell(
+            ctx,
+            language,
+            cloudStatus,
+            setVideoState,
+            getClipParent,
+            goToClipParent,
+          ),
       },
       {
         id: 'Type',
@@ -390,7 +399,7 @@ const useTable = (
         sortingFn: viewPointCountSort,
       },
     ],
-    [appState, setVideoState],
+    [appState, setVideoState, getClipParent, goToClipParent],
   );
 
   const manualColumns = useMemo<ColumnDef<RendererVideo>[]>(

--- a/src/renderer/components/Tables/VideoSelectionTable.tsx
+++ b/src/renderer/components/Tables/VideoSelectionTable.tsx
@@ -1,12 +1,7 @@
 import { AppState, RendererVideo } from 'main/types';
 
 import { Cell, flexRender, Header, Row, Table } from '@tanstack/react-table';
-import React, {
-  Fragment,
-  RefObject,
-  useCallback,
-  useEffect,
-} from 'react';
+import React, { Fragment, RefObject, useCallback, useEffect } from 'react';
 import {
   ArrowDown,
   ArrowUp,
@@ -35,11 +30,15 @@ interface IProps {
 const VideoSelectionTable = (props: IProps) => {
   const { appState, setAppState, persistentProgress, table } = props;
   const {
+    category,
     videoFilterTags,
     dateRangeFilter,
     storageFilter,
     preferredViewpoint,
   } = appState;
+  const selectedVideo = appState.selectedVideos[0];
+  const { pageIndex, pageSize } = table.getState().pagination;
+  const selectedRowRef = React.useRef<HTMLTableRowElement>(null);
 
   /**
    * Mark the row as selected and update the video player to play the first
@@ -177,6 +176,41 @@ const VideoSelectionTable = (props: IProps) => {
     };
   }, [table, onRowClick, videoFilterTags, dateRangeFilter, storageFilter]);
 
+  useEffect(() => {
+    if (!selectedVideo) return undefined;
+
+    const sortedRows = table.getSortedRowModel().rows;
+    const selectedIndex = sortedRows.findIndex((row) =>
+      [row.original, ...row.original.multiPov].some((video) =>
+        videoMatch(video, selectedVideo),
+      ),
+    );
+
+    if (selectedIndex === -1) return undefined;
+
+    const selectedPageIndex = Math.floor(selectedIndex / pageSize);
+
+    if (selectedPageIndex !== pageIndex) {
+      table.setPageIndex(selectedPageIndex);
+      return undefined;
+    }
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      selectedRowRef.current?.scrollIntoView({ block: 'center' });
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [
+    category,
+    selectedVideo,
+    table,
+    pageIndex,
+    pageSize,
+    videoFilterTags,
+    dateRangeFilter,
+    storageFilter,
+  ]);
+
   /**
    * Render an individual header.
    */
@@ -255,6 +289,7 @@ const VideoSelectionTable = (props: IProps) => {
   const renderBaseRow = (
     row: Row<RendererVideo>,
     selected: boolean,
+    appStateSelected: boolean,
     sortedIndex: number,
   ) => {
     const cells = row.getVisibleCells();
@@ -269,6 +304,7 @@ const VideoSelectionTable = (props: IProps) => {
     return (
       <tr
         key={row.id}
+        ref={appStateSelected ? selectedRowRef : undefined}
         className={className}
         onClick={(event) => onRowClick(event, row)}
       >
@@ -281,7 +317,6 @@ const VideoSelectionTable = (props: IProps) => {
    * Render an individual row of the table.
    */
   const renderRow = (row: Row<RendererVideo>, sortedIndex: number) => {
-    const selectedVideo = appState.selectedVideos[0];
     // Programmatic navigation, such as jumping from a clip to its source,
     // updates appState before react-table has a selected row in the new view.
     const appStateSelected =
@@ -299,7 +334,7 @@ const VideoSelectionTable = (props: IProps) => {
 
     return (
       <Fragment key={row.id}>
-        {renderBaseRow(row, selected, sortedIndex)}
+        {renderBaseRow(row, selected, appStateSelected, sortedIndex)}
       </Fragment>
     );
   };

--- a/src/renderer/components/Tables/VideoSelectionTable.tsx
+++ b/src/renderer/components/Tables/VideoSelectionTable.tsx
@@ -15,7 +15,7 @@ import {
   ChevronsLeft,
   ChevronsRight,
 } from 'lucide-react';
-import { povDiskFirstNameSort } from '../../rendererutils';
+import { povDiskFirstNameSort, videoMatch } from '../../rendererutils';
 import { Button } from '../Button/Button';
 import { getLocalePhrase } from 'localisation/translations';
 import { ScrollArea } from '../ScrollArea/ScrollArea';
@@ -281,9 +281,21 @@ const VideoSelectionTable = (props: IProps) => {
    * Render an individual row of the table.
    */
   const renderRow = (row: Row<RendererVideo>, sortedIndex: number) => {
+    const selectedVideo = appState.selectedVideos[0];
+    // Programmatic navigation, such as jumping from a clip to its source,
+    // updates appState before react-table has a selected row in the new view.
+    const appStateSelected =
+      selectedVideo !== undefined &&
+      [row.original, ...row.original.multiPov].some((video) =>
+        videoMatch(video, selectedVideo),
+      );
+
     const selected =
       row.getIsSelected() ||
-      (!table.getIsSomeRowsSelected() && row.index === 0);
+      appStateSelected ||
+      (!table.getIsSomeRowsSelected() &&
+        appState.selectedVideos.length === 0 &&
+        row.index === 0);
 
     return (
       <Fragment key={row.id}>


### PR DESCRIPTION
## Summary

- Persist clip source metadata, including the source category, source video name, and clip offset.
- Add a source button to the Clips table that jumps back to the original recording at the captured offset.
- Disable the source action when the original recording is unavailable, while preserving a legacy hash/start-time fallback for older clips.
- Add localized tooltip text for the new source action.

## Validation

- `npm.cmd run build`
- Targeted ESLint for the changed renderer/localisation/main files that are lint-clean. `src/main/util.ts` still has existing `no-explicit-any` lint failures outside this change when linted directly.
- Packaged app smoke test: verified the Clips table source button navigates from a clip to the original recording at the saved offset.