### PR TITLE
Keep pull lock state across cloud POV updates

### DIFF
--- a/src/activitys/Activity.ts
+++ b/src/activitys/Activity.ts
@@ -28,6 +28,8 @@ export default abstract class Activity {
 
   protected _overrun: number = 0;
 
+  protected hash = crypto.createHash('md5');
+
   protected cfg = ConfigService.getInstance();
 
   constructor(startDate: Date, category: VideoCategory, flavour: Flavour) {
@@ -184,7 +186,6 @@ export default abstract class Activity {
 
     const uniqueString = deterministicFields.join(' ') + sortedNames.join(' ');
 
-    // Hash instances are one-shot after digest(), so keep this call stateless.
-    return crypto.createHash('md5').update(uniqueString).digest('hex');
+    return this.hash.update(uniqueString).digest('hex');
   }
 }

--- a/src/activitys/Activity.ts
+++ b/src/activitys/Activity.ts
@@ -28,8 +28,6 @@ export default abstract class Activity {
 
   protected _overrun: number = 0;
 
-  protected hash = crypto.createHash('md5');
-
   protected cfg = ConfigService.getInstance();
 
   constructor(startDate: Date, category: VideoCategory, flavour: Flavour) {
@@ -186,6 +184,7 @@ export default abstract class Activity {
 
     const uniqueString = deterministicFields.join(' ') + sortedNames.join(' ');
 
-    return this.hash.update(uniqueString).digest('hex');
+    // Hash instances are one-shot after digest(), so keep this call stateless.
+    return crypto.createHash('md5').update(uniqueString).digest('hex');
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,7 +13,6 @@ import {
   StorageFilter,
   ActivityStatus,
   AdvancedLoggingStatus,
-  KillVideoStatus,
 } from 'main/types';
 import Box from '@mui/material/Box';
 import { getLocalePhrase, Language } from 'localisation/translations';
@@ -26,6 +25,7 @@ import {
   videoMatch,
   videoMatchName,
 } from './rendererutils';
+import { getVideoGroup, withMatchedVideoProtection } from './videoProtection';
 import { TooltipProvider } from './components/Tooltip/Tooltip';
 import Toaster from './components/Toast/Toaster';
 import SideMenu from './SideMenu';
@@ -347,19 +347,15 @@ const WarcraftRecorder = () => {
   const displayProtectCloudVideos = (videoNames: unknown) => {
     const names = videoNames as string[];
 
-    setVideoState((prev) => {
-      const matches = prev.filter(
-        (rv) => rv.cloud && names.includes(rv.videoName),
-      );
+    setVideoState((prev) =>
+      prev.map((rv) => {
+        const matches = getVideoGroup(rv).filter(
+          (video) => video.cloud && names.includes(video.videoName),
+        );
 
-      matches.forEach((match) => {
-        // Pretty sure only one of these matters.
-        match.protected = true;
-        match.isProtected = true;
-      });
-
-      return prev;
-    });
+        return withMatchedVideoProtection(rv, matches, true);
+      }),
+    );
 
     setAppState((prevState) => {
       return {
@@ -374,19 +370,15 @@ const WarcraftRecorder = () => {
   const displayUnprotectCloudVideos = (videoNames: unknown) => {
     const names = videoNames as string[];
 
-    setVideoState((prev) => {
-      const matches = prev.filter(
-        (rv) => rv.cloud && names.includes(rv.videoName),
-      );
+    setVideoState((prev) =>
+      prev.map((rv) => {
+        const matches = getVideoGroup(rv).filter(
+          (video) => video.cloud && names.includes(video.videoName),
+        );
 
-      matches.forEach((match) => {
-        // Pretty sure only one of these matters.
-        match.protected = false;
-        match.isProtected = false;
-      });
-
-      return prev;
-    });
+        return withMatchedVideoProtection(rv, matches, false);
+      }),
+    );
 
     setAppState((prevState) => {
       return {

--- a/src/renderer/CategoryPage.tsx
+++ b/src/renderer/CategoryPage.tsx
@@ -30,6 +30,12 @@ import {
   getVideoStorageFilter,
   povDiskFirstNameSort,
 } from './rendererutils';
+import {
+  canChangeVideoProtection,
+  getNextVideoGroupsProtected,
+  getVideoGroup,
+  withMatchedVideoProtection,
+} from 'renderer/videoProtection';
 import Separator from './components/Separator/Separator';
 import { Button } from './components/Button/Button';
 import VideoSelectionTable from './components/Tables/VideoSelectionTable';
@@ -50,6 +56,7 @@ import { Phrase } from 'localisation/phrases';
 import BulkTransferDialog from './BulkTransferDialog';
 import VideoChat from './VideoChat';
 import ConfirmChatNamePrompt from './ConfirmChatNamePrompt';
+import { protectVideosWithStorage } from './videoProtectionActions';
 
 interface IProps {
   category: VideoCategory;
@@ -341,22 +348,21 @@ const CategoryPage = (props: IProps) => {
     );
   };
 
-  const getAllSelectedViewpoints = () => {
+  const getSelectedViewpointGroups = () => {
     const { rows } = table.getSelectedRowModel();
 
     if (rows.length > 0) {
-      const parents = rows.map((r) => r.original);
-      const children = parents.flatMap((v) => v.multiPov);
-      return parents.concat(children);
+      return rows.map((r) => getVideoGroup(r.original));
     }
 
     const first = filteredState[0] ? filteredState[0] : categoryState[0];
-    return [first, ...first.multiPov];
+    return first ? [getVideoGroup(first)] : [];
   };
 
   const getVideoSelection = () => {
     const selectedRows = table.getSelectedRowModel().rows;
-    const selectedViewpoints = getAllSelectedViewpoints();
+    const selectedViewpointGroups = getSelectedViewpointGroups();
+    const selectedViewpoints = selectedViewpointGroups.flat();
 
     // We don't want multi player mode to be accessible if there isn't
     // multiple viewpoints, so check for that. Important to filter by
@@ -377,10 +383,8 @@ const CategoryPage = (props: IProps) => {
 
     const multiPlayerOpts = (
       selectedRow
-        ? [selectedRow.original, ...selectedRow.original.multiPov]
-        : filteredState[0]
-          ? [filteredState[0], ...filteredState[0].multiPov]
-          : [categoryState[0], ...categoryState[0].multiPov]
+        ? getVideoGroup(selectedRow.original)
+        : selectedViewpointGroups[0] || []
     )
       .sort(povDiskFirstNameSort)
       .filter(dedup);
@@ -389,66 +393,51 @@ const CategoryPage = (props: IProps) => {
     const unique = [...new Set(names)];
     const allowMultiPlayer = unique.length > 1;
 
-    const protectVideo = (
+    const protectVideo = async (
       _event: React.SyntheticEvent,
-      protect: boolean,
+      protectedState: boolean,
       videos: RendererVideo[],
     ) => {
-      const toProtectDisk = videos.filter((v) => !v.cloud);
-      const toProtectCloud = videos.filter((v) => v.cloud);
+      const updated = await protectVideosWithStorage(
+        window.electron.ipcRenderer,
+        videos,
+        protectedState,
+      );
 
-      window.electron.ipcRenderer.sendMessage('videoButtonDisk', [
-        'protect',
-        protect,
-        toProtectDisk,
-      ]);
-
-      window.electron.ipcRenderer.sendMessage('videoButtonCloud', [
-        'protect',
-        protect,
-        toProtectCloud,
-      ]);
-
-      setVideoState((prev) => {
-        const state = [...prev];
-
-        state.forEach((rv) => {
-          // A video is uniquely identified by its name and storage type.
-          const match = videos.find(
-            (v) => v.videoName === rv.videoName && v.cloud === rv.cloud,
-          );
-
-          if (match) {
-            rv.isProtected = protect;
-          }
-        });
-
-        return state;
-      });
+      setVideoState((prev) =>
+        prev.map((rv) =>
+          withMatchedVideoProtection(rv, updated, protectedState),
+        ),
+      );
     };
 
     const renderProtectButton = () => {
       const toProtect = selectedViewpoints;
 
-      // If any videos in our selection are not protected, then the button's
-      // action is to protect.
-      const lock = !toProtect.every((v) => v.isProtected);
+      const nextProtected = getNextVideoGroupsProtected(
+        selectedViewpointGroups,
+      );
 
       // Disable the protect button if there are no selected viewpoints, if we
       // don't have write permissions, or if the action is to unprotect and we
       // don't have delete permissions.
-      const noPermission =
-        (!write && toProtect.some((v) => v.cloud)) || // Some in the selection are cloud videos and no write permission.
-        (!del && !lock && toProtect.some((v) => v.cloud)); // Some in the selection are locked cloud videos no delete permission.
+      const noPermission = !canChangeVideoProtection(toProtect, nextProtected, {
+        write,
+        del,
+      });
 
       const disabled = noPermission || toProtect.length < 1;
-      const icon = lock ? <LockKeyhole size={18} /> : <LockOpen size={18} />;
+      const icon = nextProtected ? (
+        <LockKeyhole size={18} />
+      ) : (
+        <LockOpen size={18} />
+      );
 
       let tooltip = '';
 
       if (noPermission) {
         tooltip = getLocalePhrase(language, Phrase.GuildNoPermission);
-      } else if (lock) {
+      } else if (nextProtected) {
         tooltip = getLocalePhrase(language, Phrase.StarSelected);
       } else {
         tooltip = getLocalePhrase(language, Phrase.UnstarSelected);
@@ -461,7 +450,7 @@ const CategoryPage = (props: IProps) => {
               variant="secondary"
               size="sm"
               disabled={disabled}
-              onClick={(e) => protectVideo(e, lock, toProtect)}
+              onClick={(e) => protectVideo(e, nextProtected, toProtect)}
               className="border border-background"
             >
               {icon}

--- a/src/renderer/components/Tables/Cells.tsx
+++ b/src/renderer/components/Tables/Cells.tsx
@@ -16,6 +16,14 @@ import {
   isMythicPlusUtil,
   getDungeonName,
 } from 'renderer/rendererutils';
+import {
+  canChangeVideoProtection,
+  getNextVideoGroupProtected,
+  getVideoGroup,
+  isVideoGroupProtected,
+  withMatchedVideoProtection,
+} from 'renderer/videoProtection';
+import { protectVideosWithStorage } from 'renderer/videoProtectionActions';
 import { Box, Checkbox } from '@mui/material';
 import { affixImages, specImages } from 'renderer/images';
 import { Language, Phrase } from 'localisation/phrases';
@@ -108,52 +116,47 @@ export const populateDetailsCell = (
   const { write, del } = cloudStatus;
 
   const renderProtectedIcon = () => {
-    // If any videos in our selection are not protected, then the button's
-    // action is to protect.
-    const toProtect = [video, ...video.multiPov];
-    const lock = !toProtect.every((v) => v.isProtected);
+    const toProtect = getVideoGroup(video);
+    const groupProtected = isVideoGroupProtected(toProtect);
+    const nextProtected = getNextVideoGroupProtected(toProtect);
 
     // Disable the protect button if there are no selected viewpoints, or if
     // the action is to unprotect and we don't have delete permissions.
-    const noPermission = !del && !lock && toProtect.some((v) => v.cloud);
+    const noPermission = !canChangeVideoProtection(toProtect, nextProtected, {
+      write,
+      del,
+    });
     const disabled = noPermission || toProtect.length < 1;
 
-    const icon = lock ? <LockOpen size={20} /> : <LockKeyhole size={20} />;
+    const icon = groupProtected ? (
+      <LockKeyhole size={20} />
+    ) : (
+      <LockOpen size={20} />
+    );
 
     let tooltip = '';
 
     if (noPermission) {
       tooltip = getLocalePhrase(language, Phrase.GuildNoPermission);
-    } else if (lock) {
+    } else if (nextProtected) {
       tooltip = getLocalePhrase(language, Phrase.StarSelected);
     } else {
       tooltip = getLocalePhrase(language, Phrase.UnstarSelected);
     }
 
-    const toggleProtected = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const toggleProtected = async (e: React.MouseEvent<HTMLButtonElement>) => {
       stopPropagation(e);
-      const toProtectDisk = toProtect.filter((v) => !v.cloud);
-      const toProtectCloud = toProtect.filter((v) => v.cloud);
+      const updated = await protectVideosWithStorage(
+        ipc,
+        toProtect,
+        nextProtected,
+      );
 
-      ipc.sendMessage('videoButtonDisk', ['protect', lock, toProtectDisk]);
-      ipc.sendMessage('videoButtonCloud', ['protect', lock, toProtectCloud]);
-
-      setVideoState((prev) => {
-        const state = [...prev];
-
-        state.forEach((rv) => {
-          // A video is uniquely identified by its name and storage type.
-          const match = toProtect.find(
-            (v) => v.videoName === rv.videoName && v.cloud === rv.cloud,
-          );
-
-          if (match) {
-            rv.isProtected = lock;
-          }
-        });
-
-        return state;
-      });
+      setVideoState((prev) =>
+        prev.map((rv) =>
+          withMatchedVideoProtection(rv, updated, nextProtected),
+        ),
+      );
     };
 
     return (

--- a/src/renderer/components/Tables/Sorting.ts
+++ b/src/renderer/components/Tables/Sorting.ts
@@ -10,6 +10,7 @@ import {
   isRaidUtil,
   raidResultToPercent,
 } from 'renderer/rendererutils';
+import { getVideoGroup, isVideoGroupProtected } from 'renderer/videoProtection';
 
 export const resultSort = (
   a: Row<RendererVideo>,
@@ -78,8 +79,8 @@ export const viewPointCountSort = (
 };
 
 export const detailSort = (a: Row<RendererVideo>, b: Row<RendererVideo>) => {
-  const aProtected = a.original.isProtected;
-  const bProtected = b.original.isProtected;
+  const aProtected = isVideoGroupProtected(getVideoGroup(a.original));
+  const bProtected = isVideoGroupProtected(getVideoGroup(b.original));
 
   const aTag = a.original.tag;
   const bTag = b.original.tag;

--- a/src/renderer/videoProtection.ts
+++ b/src/renderer/videoProtection.ts
@@ -1,0 +1,119 @@
+import { RendererVideo } from 'main/types';
+
+type VideoProtectionPermissions = {
+  write: boolean;
+  del: boolean;
+};
+
+const getVideoMultiPov = (video: RendererVideo): RendererVideo[] =>
+  Array.isArray(video.multiPov) ? video.multiPov : [];
+
+const getVideoGroup = (video: RendererVideo): RendererVideo[] => [
+  video,
+  ...getVideoMultiPov(video),
+];
+
+const isVideoProtected = (video: RendererVideo): boolean =>
+  Boolean(video.isProtected);
+
+// A pull should remain locked if any backing POV is protected locally or in cloud.
+const isVideoGroupProtected = (videos: RendererVideo[]): boolean =>
+  videos.some(isVideoProtected);
+
+// A row action unlocks a protected pull, otherwise it locks every POV in it.
+const getNextVideoGroupProtected = (videos: RendererVideo[]): boolean =>
+  !isVideoGroupProtected(videos);
+
+const areVideoGroupsProtected = (videoGroups: RendererVideo[][]): boolean =>
+  videoGroups.length > 0 && videoGroups.every(isVideoGroupProtected);
+
+// A bulk action protects the selection if any selected pull is currently unlocked.
+const getNextVideoGroupsProtected = (videoGroups: RendererVideo[][]): boolean =>
+  !areVideoGroupsProtected(videoGroups);
+
+const canChangeVideoProtection = (
+  videos: RendererVideo[],
+  protectedState: boolean,
+  permissions: VideoProtectionPermissions,
+): boolean => {
+  const hasCloudVideos = videos.some((video) => video.cloud);
+
+  if (!hasCloudVideos) {
+    return true;
+  }
+
+  return protectedState ? permissions.write : permissions.del;
+};
+
+const withVideoProtection = (
+  video: RendererVideo,
+  protectedState: boolean,
+): RendererVideo => ({
+  ...video,
+  isProtected: protectedState,
+  protected: protectedState,
+});
+
+const getVideoIdentity = (video: RendererVideo): string => {
+  // A video is uniquely identified by its storage type and storage-specific source.
+  if (video.cloud) {
+    return `cloud:${video.videoName}`;
+  }
+
+  if (video.videoSource) {
+    return `disk:${video.videoSource}`;
+  }
+
+  if (video.uniqueId) {
+    return `unique:${video.uniqueId}`;
+  }
+
+  return `${video.cloud ? 'cloud' : 'disk'}:${video.videoName}`;
+};
+
+const videoIdentityMatches = (a: RendererVideo, b: RendererVideo): boolean =>
+  getVideoIdentity(a) === getVideoIdentity(b);
+
+// Cloud updates can target a nested POV, so update both the row video and its multiPov entries.
+const withMatchedVideoProtection = (
+  video: RendererVideo,
+  matches: RendererVideo[],
+  protectedState: boolean,
+): RendererVideo => {
+  const shouldUpdate = (candidate: RendererVideo) =>
+    matches.some((match) => videoIdentityMatches(candidate, match));
+
+  const nextVideo = shouldUpdate(video)
+    ? withVideoProtection(video, protectedState)
+    : video;
+
+  const multiPov = getVideoMultiPov(video);
+  const nextMultiPov = multiPov.map((pov) =>
+    shouldUpdate(pov) ? withVideoProtection(pov, protectedState) : pov,
+  );
+
+  const multiPovChanged = nextMultiPov.some(
+    (pov, index) => pov !== multiPov[index],
+  );
+
+  if (nextVideo === video && !multiPovChanged) {
+    return video;
+  }
+
+  return {
+    ...nextVideo,
+    multiPov: nextMultiPov,
+  };
+};
+
+export {
+  areVideoGroupsProtected,
+  canChangeVideoProtection,
+  getVideoGroup,
+  getNextVideoGroupProtected,
+  getNextVideoGroupsProtected,
+  isVideoGroupProtected,
+  isVideoProtected,
+  withMatchedVideoProtection,
+  withVideoProtection,
+};

--- a/src/renderer/videoProtectionActions.ts
+++ b/src/renderer/videoProtectionActions.ts
@@ -1,0 +1,52 @@
+import { RendererVideo } from 'main/types';
+
+type VideoProtectionIpc = {
+  invoke(
+    channel: 'videoButtonDisk' | 'videoButtonCloud',
+    args: unknown[],
+  ): Promise<unknown>;
+};
+
+const protectVideosWithStorage = async (
+  ipc: VideoProtectionIpc,
+  videos: RendererVideo[],
+  protectedState: boolean,
+): Promise<RendererVideo[]> => {
+  const disk = videos.filter((video) => !video.cloud);
+  const cloud = videos.filter((video) => video.cloud);
+  const updated: RendererVideo[] = [];
+
+  // Use invoke so the renderer only updates videos whose protection change persisted.
+  if (cloud.length > 0) {
+    try {
+      const cloudUpdated = await ipc.invoke('videoButtonCloud', [
+        'protect',
+        protectedState,
+        cloud,
+      ]);
+      updated.push(...(Array.isArray(cloudUpdated) ? cloudUpdated : cloud));
+    } catch (error) {
+      console.error(
+        '[Renderer] Failed to update cloud video protection',
+        error,
+      );
+    }
+  }
+
+  if (disk.length > 0) {
+    try {
+      const diskUpdated = await ipc.invoke('videoButtonDisk', [
+        'protect',
+        protectedState,
+        disk,
+      ]);
+      updated.push(...(Array.isArray(diskUpdated) ? diskUpdated : disk));
+    } catch (error) {
+      console.error('[Renderer] Failed to update disk video protection', error);
+    }
+  }
+
+  return updated;
+};
+
+export { protectVideosWithStorage };

--- a/src/storage/CloudClient.ts
+++ b/src/storage/CloudClient.ts
@@ -1221,45 +1221,58 @@ export default class CloudClient implements StorageClient {
       this.deleteVideos(toDelete);
     });
 
+    ipcMain.handle('videoButtonCloud', async (_event, args) => {
+      return this.handleVideoButton(args);
+    });
+
     // VideoButton event listeners.
     ipcMain.on('videoButtonCloud', async (_event, args) => {
-      const ready = await this.ready();
-      const action = args[0] as string;
-
-      if (!ready) {
-        console.warn('[Manager] Cannot process event', action, args);
-        return;
-      }
-
-      if (action === 'protect') {
-        const protect = args[1] as boolean;
-        const videos = args[2] as RendererVideo[];
-        const cloud = videos.filter((v) => v.cloud);
-        const toProtect = cloud.map((v) => v.videoName);
-        if (toProtect.length < 1) return;
-        this.protectVideos(toProtect, protect);
-      }
-
-      if (action === 'tag') {
-        const tag = args[1] as string;
-        const videos = args[2] as RendererVideo[];
-        const cloud = videos.filter((v) => v.cloud);
-        const toTag = cloud.map((v) => v.videoName);
-        if (toTag.length < 1) return;
-        this.tagVideos(toTag, tag);
-      }
-
-      if (action === 'download') {
-        const video = args[1] as RendererVideo;
-        VideoProcessQueue.getInstance().queueDownload(video);
-      }
-
-      if (action === 'upload') {
-        const src = args[1] as string;
-        const item: UploadQueueItem = { path: src };
-        VideoProcessQueue.getInstance().queueUpload(item);
-      }
+      this.handleVideoButton(args).catch((error) => {
+        console.error('[CloudClient] Failed to process video button', error);
+      });
     });
+  }
+
+  private async handleVideoButton(args: unknown[]) {
+    const ready = await this.ready();
+    const action = args[0] as string;
+
+    if (!ready) {
+      console.warn('[Manager] Cannot process event', action, args);
+      throw new Error(`Cloud client is not ready for ${action}`);
+    }
+
+    if (action === 'protect') {
+      const protect = args[1] as boolean;
+      const videos = args[2] as RendererVideo[];
+      const cloud = videos.filter((v) => v.cloud);
+      const toProtect = cloud.map((v) => v.videoName);
+      if (toProtect.length < 1) return;
+      await this.protectVideos(toProtect, protect);
+      return cloud;
+    }
+
+    if (action === 'tag') {
+      const tag = args[1] as string;
+      const videos = args[2] as RendererVideo[];
+      const cloud = videos.filter((v) => v.cloud);
+      const toTag = cloud.map((v) => v.videoName);
+      if (toTag.length < 1) return;
+      this.tagVideos(toTag, tag);
+    }
+
+    if (action === 'download') {
+      const video = args[1] as RendererVideo;
+      VideoProcessQueue.getInstance().queueDownload(video);
+    }
+
+    if (action === 'upload') {
+      const src = args[1] as string;
+      const item: UploadQueueItem = { path: src };
+      VideoProcessQueue.getInstance().queueUpload(item);
+    }
+
+    return undefined;
   }
 
   /**

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -138,9 +138,37 @@ export default class DiskClient implements StorageClient {
   }
 
   public async protectVideos(videoPaths: string[], protect: boolean) {
-    videoPaths.forEach((videoPath) =>
-      this.protectVideoDisk(protect, videoPath),
+    await Promise.all(
+      videoPaths.map((videoPath) => this.protectVideoDisk(protect, videoPath)),
     );
+  }
+
+  private async protectVideosWithResults(
+    videoPaths: string[],
+    protect: boolean,
+  ) {
+    const results = await Promise.allSettled(
+      videoPaths.map(async (videoPath) => {
+        await this.protectVideoDisk(protect, videoPath);
+        return videoPath;
+      }),
+    );
+
+    results.forEach((result) => {
+      if (result.status === 'rejected') {
+        console.error(
+          '[DiskClient] Failed to persist video protection',
+          result.reason,
+        );
+      }
+    });
+
+    return results
+      .filter(
+        (result): result is PromiseFulfilledResult<string> =>
+          result.status === 'fulfilled',
+      )
+      .map((result) => result.value);
   }
 
   /**
@@ -157,7 +185,7 @@ export default class DiskClient implements StorageClient {
         err,
       );
 
-      return;
+      throw err;
     }
 
     if (protect) {
@@ -219,6 +247,40 @@ export default class DiskClient implements StorageClient {
     }
   }
 
+  private async handleVideoButton(args: unknown[]) {
+    const action = args[0] as string;
+
+    if (action === 'open') {
+      // Open only called for disk based video, see openURL for cloud version.
+      const src = args[1] as string;
+      const cloud = args[2] as boolean;
+      assert(!cloud);
+      openSystemExplorer(src);
+    }
+
+    if (action === 'protect') {
+      const protect = args[1] as boolean;
+      const videos = args[2] as RendererVideo[];
+      const disk = videos.filter((v) => !v.cloud);
+      const toProtect = disk.map((v) => v.videoSource);
+      const protectedPaths = await this.protectVideosWithResults(
+        toProtect,
+        protect,
+      );
+      return disk.filter((video) => protectedPaths.includes(video.videoSource));
+    }
+
+    if (action === 'tag') {
+      const tag = args[1] as string;
+      const videos = args[2] as RendererVideo[];
+      const disk = videos.filter((v) => !v.cloud);
+      const toTag = disk.map((v) => v.videoSource);
+      this.tagVideos(toTag, tag);
+    }
+
+    return undefined;
+  }
+
   private setupListeners() {
     ipcMain.on('deleteVideosDisk', async (_event, args) => {
       const videos = args as RendererVideo[];
@@ -227,32 +289,14 @@ export default class DiskClient implements StorageClient {
       this.deleteVideos(toDelete);
     });
 
+    ipcMain.handle('videoButtonDisk', async (_event, args) => {
+      return this.handleVideoButton(args);
+    });
+
     ipcMain.on('videoButtonDisk', async (_event, args) => {
-      const action = args[0] as string;
-
-      if (action === 'open') {
-        // Open only called for disk based video, see openURL for cloud version.
-        const src = args[1] as string;
-        const cloud = args[2] as boolean;
-        assert(!cloud);
-        openSystemExplorer(src);
-      }
-
-      if (action === 'protect') {
-        const protect = args[1] as boolean;
-        const videos = args[2] as RendererVideo[];
-        const disk = videos.filter((v) => !v.cloud);
-        const toProtect = disk.map((v) => v.videoSource);
-        this.protectVideos(toProtect, protect);
-      }
-
-      if (action === 'tag') {
-        const tag = args[1] as string;
-        const videos = args[2] as RendererVideo[];
-        const disk = videos.filter((v) => !v.cloud);
-        const toTag = disk.map((v) => v.videoSource);
-        this.tagVideos(toTag, tag);
-      }
+      this.handleVideoButton(args).catch((error) => {
+        console.error('[DiskClient] Failed to process video button', error);
+      });
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #843.

- Treat a pull as locked when any POV in the pull group is protected.
- Keep lock state consistent for grouped disk/cloud POVs in row actions, bulk actions, sorting, and cloud protection updates.
- Await disk/cloud lock persistence before updating renderer state, so the UI does not mark videos as changed when storage rejects the operation.

## Testing

- `npx.cmd eslint src/storage/DiskClient.ts src/storage/CloudClient.ts src/renderer/App.tsx src/renderer/CategoryPage.tsx src/renderer/components/Tables/Cells.tsx src/renderer/components/Tables/Sorting.ts src/renderer/videoProtection.ts src/renderer/videoProtectionActions.ts`
- `git diff --check -- src/storage/DiskClient.ts src/storage/CloudClient.ts src/renderer/App.tsx src/renderer/CategoryPage.tsx src/renderer/components/Tables/Cells.tsx src/renderer/components/Tables/Sorting.ts src/renderer/videoProtection.ts src/renderer/videoProtectionActions.ts`
- `npm.cmd run build`
- Local app smoke test with real videos: verified local lock persistence and grouped pull lock behavior after a simulated cloud POV update.