### PR TITLE
[codex] Fix repeatable activity unique hash

### DIFF
--- a/src/activitys/Activity.ts
+++ b/src/activitys/Activity.ts
@@ -28,8 +28,6 @@ export default abstract class Activity {
 
   protected _overrun: number = 0;
 
-  protected hash = crypto.createHash('md5');
-
   protected cfg = ConfigService.getInstance();
 
   constructor(startDate: Date, category: VideoCategory, flavour: Flavour) {
@@ -186,6 +184,7 @@ export default abstract class Activity {
 
     const uniqueString = deterministicFields.join(' ') + sortedNames.join(' ');
 
-    return this.hash.update(uniqueString).digest('hex');
+    // Hash instances are one-shot after digest(), so keep this call stateless.
+    return crypto.createHash('md5').update(uniqueString).digest('hex');
   }
 }


### PR DESCRIPTION
## Summary

Fixes Activity.getUniqueHash() so repeated calls on the same activity instance remain valid and deterministic.

The previous implementation stored a Node Hash instance on the activity. Node hash instances are one-shot after digest(), so a second call could fail with Digest already called. The method now creates a fresh hash instance per call.

## Scope

- Changed only src/activitys/Activity.ts
- No AI-created or AI-modified tests included

## Validation

- git diff --check
- git diff --cached --check
- git diff --check origin/main...HEAD on the isolated PR branch
- npm run build
- Local ad-hoc runtime check confirming two consecutive getUniqueHash() calls return the same hash without throwing