### PR TITLE
Fix challenge mode timer finalization

### DIFF
--- a/src/activitys/Activity.ts
+++ b/src/activitys/Activity.ts
@@ -42,6 +42,10 @@ export default abstract class Activity {
   abstract getMetadata(): Metadata;
   abstract getFileName(): string;
 
+  prepareMetadata(): Promise<void> {
+    return Promise.resolve();
+  }
+
   get zoneID() {
     return this._zoneID;
   }

--- a/src/activitys/ChallengeModeDungeon.ts
+++ b/src/activitys/ChallengeModeDungeon.ts
@@ -20,6 +20,8 @@ import CloudClient from 'storage/CloudClient';
 export default class ChallengeModeDungeon extends Activity {
   private static readonly TIMER_GRACE_SECONDS = 1;
 
+  private static readonly REMOTE_TIMER_FINALIZATION_TIMEOUT_MS = 3000;
+
   private _mapID: number;
 
   private _level: number;
@@ -31,6 +33,10 @@ export default class ChallengeModeDungeon extends Activity {
   private _timeline: ChallengeModeTimelineSegment[] = [];
 
   private affixes: number[] = [];
+
+  private keystoneTimersPromise?: Promise<void>;
+
+  private keystoneTimersFinalized = false;
 
   constructor(
     startDate: Date,
@@ -46,22 +52,36 @@ export default class ChallengeModeDungeon extends Activity {
     this._level = level;
     this.affixes = affixes;
 
-    this._timings = dungeonTimersByMapId[this.mapID];
-    this.getKeystoneTimers();
-
+    // Classic challenge mode timers are local-only; the remote endpoint is for Retail.
     if (flavor === Flavour.Classic) {
       console.info('[ChallengeModeDungeon] Using Classic timers for', mapID);
       this._timings = mopChallengeModesTimers[mapID];
+    } else {
+      this._timings = dungeonTimersByMapId[this.mapID];
+      this.keystoneTimersPromise = this.getKeystoneTimers();
     }
 
     this.overrun = 0;
   }
 
   private async getKeystoneTimers() {
+    if (this.flavour !== Flavour.Retail) {
+      return;
+    }
+
     try {
       const timings = await CloudClient.getInstance().getKeystoneTimers(
         this.mapID,
       );
+
+      if (this.keystoneTimersFinalized) {
+        console.info(
+          '[ChallengeModeDungeon] Ignoring keystone timings received after metadata finalization for map',
+          this.mapID,
+        );
+        return;
+      }
+
       this._timings = [timings[3], timings[2], timings[1]];
 
       console.info(
@@ -77,6 +97,34 @@ export default class ChallengeModeDungeon extends Activity {
         'using local fallback',
       );
     }
+  }
+
+  override async prepareMetadata(): Promise<void> {
+    if (this.keystoneTimersFinalized) {
+      return;
+    }
+
+    if (!this.keystoneTimersPromise) {
+      return;
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finalizationTimeout = new Promise<void>((resolve) => {
+      timeout = setTimeout(
+        resolve,
+        ChallengeModeDungeon.REMOTE_TIMER_FINALIZATION_TIMEOUT_MS,
+      );
+    });
+
+    // Lock in either remote timers or local fallback before metadata reads upgradeLevel.
+    await Promise.race([this.keystoneTimersPromise, finalizationTimeout]);
+
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    this.keystoneTimersFinalized = true;
   }
 
   get endDate() {

--- a/src/parsing/LogHandler.ts
+++ b/src/parsing/LogHandler.ts
@@ -313,6 +313,8 @@ export default abstract class LogHandler {
     }
 
     try {
+      // Let activities settle async state before metadata and filename are derived.
+      await lastActivity.prepareMetadata();
       const metadata = lastActivity.getMetadata();
       const { duration } = metadata;
       const suffix = lastActivity.getFileName();


### PR DESCRIPTION
## Problem

`ChallengeModeDungeon` previously started `getKeystoneTimers()` for every dungeon flavour. For Classic/MoP Challenge Mode, the constructor then replaced timings with local MoP challenge mode timers, but the earlier remote request could still resolve later and overwrite them with Retail keystone timers.

That made Classic results unsafe, and also made Retail `upgradeLevel` timing-dependent: metadata could use local fallback timers or remote timers depending on when the remote response arrived.

## Summary

Classic/MoP Challenge Mode now uses only local challenge mode timers and no longer starts the Retail remote keystone timer request. Retail still starts with local fallback timers, but finalizes remote timer updates before metadata and filename generation.

Late remote responses after metadata finalization are ignored so `upgradeLevel`, `resultInfo`, metadata, and filename generation do not depend on remote response timing.

## Scope

- Updated `Activity` with a default `prepareMetadata()` hook
- Awaited `prepareMetadata()` in `LogHandler.endActivity()` before metadata/filename reads
- Restricted remote keystone timer fetching/finalization to Retail `ChallengeModeDungeon`
- Added comments around the race-sensitive timer flow

## Validation

- `git diff --check`
- `npm run build`
- Local ad-hoc runtime check for:
  - Classic does not fetch remote timers
  - Retail fast remote response updates timers before metadata
  - Retail slow remote response uses local fallback
  - Late remote response does not change finalized timers

No AI-created or modified tests are included.