### PR TITLE
Sanitize kill video output filenames

### DIFF
--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -823,7 +823,7 @@ export default class VideoProcessQueue {
   }
 
   /**
-   * Prepare and return the audio map for a kill video.
+   * Prepare and return the output path for a kill video.
    */
   private static prepareKillVideoPath(video: RendererVideo) {
     const videoDate = video.start ?? video.mtime;
@@ -841,6 +841,9 @@ export default class VideoProcessQueue {
     }
 
     videoName += ` - Rendered at ${getOBSFormattedDate(new Date())}`;
+    // Encounter metadata can contain characters Windows rejects in filenames,
+    // so apply the same sanitizer used for normal video cuts.
+    videoName = VideoProcessQueue.sanitizeFilename(videoName);
     const storageDir = ConfigService.getInstance().get<string>('storagePath');
     const videoPath = path.join(storageDir, `${videoName}.mp4`);
 


### PR DESCRIPTION
## Summary
- Reuses the existing filename sanitizer when building kill/multiview output paths.
- Prevents encounter metadata with Windows-invalid filename characters from being passed to `path.join()`.

## Problem
Normal video cuts already sanitize output filenames, but kill/multiview renders built the filename directly from encounter metadata and timestamps. If `encounterName` or related metadata contained characters such as `:`, `?`, `*`, `/`, or `|`, the rendered video path could be invalid on Windows.

## Validation
- `git diff --check -- src/main/VideoProcessQueue.ts`
- `npm.cmd run build`