### PR TITLE
3 Features: Annotation persistence, seamless buffer replay, disk read bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,13 @@ buffer
 
 # Some stuff OBS window capture creates at runtime?
 win-capture/
+
+# Local agent, planning, and editor artifacts
+.claude/
+.vs/
+AGENTS.md
+CLAUDE.md
+EXECUTION.md
+PLAN.md
+PLAN-*.md
+Stop-Node.ps1

--- a/src/config/configSchema.ts
+++ b/src/config/configSchema.ts
@@ -53,6 +53,7 @@ export type ConfigurationSchema = {
   deathMarkers: number;
   encounterMarkers: boolean;
   roundMarkers: boolean;
+  annotationFlashSeconds: number;
   pushToTalk: boolean;
   pushToTalkKey: number;
   pushToTalkMouseButton: number;
@@ -428,6 +429,14 @@ export const configSchema = {
     default: 5,
     minimum: 0,
     maximum: 60,
+  },
+  annotationFlashSeconds: {
+    // Set via the in-player annotation duration slider, not the Settings UI, so
+    // no description Phrase is needed.
+    type: 'integer',
+    default: 5,
+    minimum: 1,
+    maximum: 30,
   },
   cloudStorage: {
     description: Phrase.CloudStorageDescription,

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { ipcMain } from 'electron';
 import {
   getBaseConfig,
   getStagingDir,
@@ -128,6 +129,19 @@ export default class VideoProcessQueue {
   private inProgressKillVideos: string[] = [];
 
   /**
+   * Resolved paths of the video sources currently loaded in the frontend
+   * player(s). Reported by the renderer. Used so we never delete a local
+   * staging copy that is currently being reviewed.
+   */
+  private activeSources = new Set<string>();
+
+  /**
+   * Staging copies that have been relocated to storage but couldn't be deleted
+   * yet because they were in use. Cleaned up once playback moves off them.
+   */
+  private pendingStagingDeletes = new Set<string>();
+
+  /**
    * Constructor.
    */
   private constructor() {
@@ -136,6 +150,17 @@ export default class VideoProcessQueue {
     this.downloadQueue = this.createDownloadQueue();
     this.killVideoQueue = this.createKillVideoQueue();
     this.relocateQueue = this.createRelocateQueue();
+    this.registerListeners();
+  }
+
+  /**
+   * Register IPC listeners.
+   */
+  private registerListeners() {
+    ipcMain.on('activeVideoSources', (_event, args) => {
+      const sources = (args as string[]) ?? [];
+      this.setActiveVideoSources(sources);
+    });
   }
 
   private createVideoQueue() {
@@ -298,8 +323,10 @@ export default class VideoProcessQueue {
    * already exists in storage, delete the now-redundant local copy; otherwise
    * (e.g. the app closed mid-relocation) re-queue it for relocation.
    *
-   * Deliberately only run at startup so we never delete a staged file that the
-   * user might be reviewing during a session.
+   * This is a startup backstop. During a session, relocated staging copies are
+   * cleaned up promptly by disposeStagingCopy once they're no longer being
+   * reviewed (tracked via activeSources). Running at startup is always safe as
+   * nothing can be open in the player yet.
    */
   public reconcileStaging = async () => {
     const stagingDir = getStagingDir(this.cfg);
@@ -332,6 +359,59 @@ export default class VideoProcessQueue {
       }),
     );
   };
+
+  /**
+   * Record which video sources are currently loaded in the frontend player(s),
+   * then clean up any deferred staging deletions that are no longer in use.
+   */
+  public setActiveVideoSources(sources: string[]) {
+    this.activeSources = new Set(sources.map((s) => path.resolve(s)));
+    this.cleanPendingStaging();
+  }
+
+  /**
+   * Dispose of a staging copy once it has been relocated to storage. If it's
+   * currently being reviewed, defer deletion until playback moves off it.
+   */
+  private async disposeStagingCopy(stagingPath: string) {
+    if (this.activeSources.has(path.resolve(stagingPath))) {
+      console.info(
+        '[VideoProcessQueue] Staging copy in use, deferring cleanup',
+        stagingPath,
+      );
+
+      this.pendingStagingDeletes.add(stagingPath);
+      return;
+    }
+
+    console.info(
+      '[VideoProcessQueue] Removing relocated staging copy',
+      stagingPath,
+    );
+
+    await deleteVideoDisk(stagingPath);
+  }
+
+  /**
+   * Delete any deferred staging copies that are no longer in use.
+   */
+  private cleanPendingStaging() {
+    this.pendingStagingDeletes.forEach((stagingPath) => {
+      if (this.activeSources.has(path.resolve(stagingPath))) {
+        // Still being reviewed; leave it for now.
+        return;
+      }
+
+      this.pendingStagingDeletes.delete(stagingPath);
+
+      console.info(
+        '[VideoProcessQueue] Removing deferred staging copy',
+        stagingPath,
+      );
+
+      deleteVideoDisk(stagingPath);
+    });
+  }
 
   /**
    * Process a video by cutting it to size and saving it to disk, also
@@ -638,6 +718,11 @@ export default class VideoProcessQueue {
       // Refresh so the frontend now resolves the video from storage. Any
       // in-progress playback of the local staging copy is unaffected.
       DiskClient.getInstance().refreshVideos();
+
+      // Remove the local staging copy now it's safely in storage, unless it's
+      // currently being reviewed (in which case it's cleaned up once playback
+      // moves on).
+      await this.disposeStagingCopy(stagingPath);
     } catch (error) {
       console.error(
         '[VideoProcessQueue] Error relocating video:',

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -1,5 +1,9 @@
 import path from 'path';
-import { getBaseConfig, shouldUpload } from '../utils/configUtils';
+import {
+  getBaseConfig,
+  getStagingDir,
+  shouldUpload,
+} from '../utils/configUtils';
 import DiskSizeMonitor from '../storage/DiskSizeMonitor';
 import ConfigService from '../config/ConfigService';
 import {
@@ -7,6 +11,7 @@ import {
   DiskStatus,
   KillVideoQueueItem,
   KillVideoStatus,
+  RelocateQueueItem,
   RendererVideo,
   SaveStatus,
   UploadQueueItem,
@@ -15,6 +20,10 @@ import {
 import {
   writeMetadataFile,
   getMetadataForVideo,
+  getMetadataFileNameForVideo,
+  getSortedVideos,
+  deleteVideoDisk,
+  exists,
   rendererVideoToMetadata,
   getFileInfo,
   fixPathWhenPackaged,
@@ -86,6 +95,14 @@ export default class VideoProcessQueue {
   private killVideoQueue: any;
 
   /**
+   * Atomic queue for relocating freshly cut videos from the local staging dir
+   * to the final storage path (e.g. a NAS). Kept separate so the slow network
+   * copy doesn't block further video cuts. Used by the "review locally while
+   * relocating to storage" feature.
+   */
+  private relocateQueue: any;
+
+  /**
    * Config service handle.
    */
   private cfg = ConfigService.getInstance();
@@ -118,6 +135,7 @@ export default class VideoProcessQueue {
     this.uploadQueue = this.createUploadQueue();
     this.downloadQueue = this.createDownloadQueue();
     this.killVideoQueue = this.createKillVideoQueue();
+    this.relocateQueue = this.createRelocateQueue();
   }
 
   private createVideoQueue() {
@@ -192,6 +210,20 @@ export default class VideoProcessQueue {
     return queue;
   }
 
+  private createRelocateQueue() {
+    const worker = this.processRelocateQueueItem.bind(this);
+    const settings = { concurrency: 1 };
+    const queue = atomicQueue(worker, settings);
+
+    /* eslint-disable prettier/prettier */
+    queue
+      .on('error', VideoProcessQueue.errorRelocatingVideo)
+      .on('idle', () => { this.relocateQueueEmpty() });
+    /* eslint-enable prettier/prettier */
+
+    return queue;
+  }
+
   /**
    * Add a video to the queue for processing, the processing it undergoes is
    * dictated by the input. This is the only public method on this class.
@@ -250,6 +282,58 @@ export default class VideoProcessQueue {
   };
 
   /**
+   * Queue a freshly cut video for relocation from the local staging dir to the
+   * final storage path.
+   */
+  public queueRelocate = async (item: RelocateQueueItem) => {
+    console.info(
+      '[VideoProcessQueue] Queuing video for relocation',
+      item.stagingPath,
+    );
+    this.relocateQueue.write(item);
+  };
+
+  /**
+   * Reconcile the local staging dir on startup. For each staged video: if it
+   * already exists in storage, delete the now-redundant local copy; otherwise
+   * (e.g. the app closed mid-relocation) re-queue it for relocation.
+   *
+   * Deliberately only run at startup so we never delete a staged file that the
+   * user might be reviewing during a session.
+   */
+  public reconcileStaging = async () => {
+    const stagingDir = getStagingDir(this.cfg);
+
+    if (!stagingDir || !(await exists(stagingDir))) {
+      return;
+    }
+
+    const storageDir = this.cfg.get<string>('storagePath');
+    const staged = await getSortedVideos(stagingDir);
+
+    await Promise.all(
+      staged.map(async (file) => {
+        const name = path.basename(file.name); // "<name>.mp4"
+        const onStorage = await exists(path.join(storageDir, name));
+
+        if (onStorage) {
+          console.info(
+            '[VideoProcessQueue] Removing relocated staging copy',
+            file.name,
+          );
+          await deleteVideoDisk(file.name);
+        } else {
+          console.info(
+            '[VideoProcessQueue] Re-queuing orphaned staging video',
+            file.name,
+          );
+          this.queueRelocate({ stagingPath: file.name, storageDir });
+        }
+      }),
+    );
+  };
+
+  /**
    * Process a video by cutting it to size and saving it to disk, also
    * writes out the metadata JSON file.
    */
@@ -258,7 +342,18 @@ export default class VideoProcessQueue {
     done: () => void,
   ): Promise<void> {
     try {
-      const outputDir = this.cfg.get<string>('storagePath');
+      const storagePath = this.cfg.get<string>('storagePath');
+      const stagingDir = getStagingDir(this.cfg);
+
+      // When a separate local buffer is configured we cut into a local staging
+      // dir so the video can be reviewed immediately, then relocate it to the
+      // (possibly slow) storage path in the background. Otherwise we cut
+      // straight to storage as before.
+      const outputDir = stagingDir ?? storagePath;
+
+      if (stagingDir) {
+        await fspromise.mkdir(stagingDir, { recursive: true });
+      }
 
       // In a lot of cases this is basically just a copy. But this also
       // covers the cases where we're cutting a section off the end of
@@ -278,6 +373,13 @@ export default class VideoProcessQueue {
       if (upload) {
         const item: UploadQueueItem = { path: videoPath };
         this.queueUpload(item);
+      }
+
+      if (stagingDir) {
+        // The cut MP4 now lives on the local disk and becomes reviewable as
+        // soon as the frontend refreshes (finishProcessingVideo). Relocate it
+        // to the final storage path in the background.
+        this.queueRelocate({ stagingPath: videoPath, storageDir: storagePath });
       }
     } catch (error) {
       console.error(
@@ -484,6 +586,74 @@ export default class VideoProcessQueue {
   }
 
   /**
+   * Relocate a freshly cut video from the local staging dir to the final
+   * storage path. Publishes atomically: the MP4/JSON are first copied into a
+   * hidden ".relocating" temp dir on the storage volume, then renamed into
+   * place (rename is atomic on the same filesystem) so a refresh never sees a
+   * half-written file. The local staging copy is left in place and cleaned up
+   * at next startup (reconcileStaging) so we never delete a file mid-review.
+   */
+  private async processRelocateQueueItem(
+    item: RelocateQueueItem,
+    done: () => void,
+  ): Promise<void> {
+    const { stagingPath, storageDir } = item;
+    const name = path.basename(stagingPath); // "<name>.mp4"
+    const stagingJson = getMetadataFileNameForVideo(stagingPath);
+
+    const tmpDir = path.join(storageDir, '.relocating');
+    const tmpMp4 = path.join(tmpDir, name);
+    const tmpJson = getMetadataFileNameForVideo(tmpMp4);
+
+    const destMp4 = path.join(storageDir, name);
+    const destJson = getMetadataFileNameForVideo(destMp4);
+
+    try {
+      await fspromise.mkdir(tmpDir, { recursive: true });
+
+      // Copy both files fully into the temp dir (the slow network part).
+      await fspromise.copyFile(stagingJson, tmpJson);
+      await fspromise.copyFile(stagingPath, tmpMp4);
+
+      // Sanity check the copied video size matches the source.
+      const [srcStat, dstStat] = await Promise.all([
+        fspromise.stat(stagingPath),
+        fspromise.stat(tmpMp4),
+      ]);
+
+      if (srcStat.size !== dstStat.size) {
+        throw new Error(
+          `Relocated size mismatch ${srcStat.size} != ${dstStat.size} for ${name}`,
+        );
+      }
+
+      // Publish: rename the JSON first, then the MP4. getSortedVideos only
+      // lists .mp4 files, so the video only becomes visible on storage once
+      // its metadata is already in place.
+      await fspromise.rename(tmpJson, destJson);
+      await fspromise.rename(tmpMp4, destMp4);
+
+      console.info('[VideoProcessQueue] Relocated video to storage', destMp4);
+
+      // Refresh so the frontend now resolves the video from storage. Any
+      // in-progress playback of the local staging copy is unaffected.
+      DiskClient.getInstance().refreshVideos();
+    } catch (error) {
+      console.error(
+        '[VideoProcessQueue] Error relocating video:',
+        String(error),
+      );
+
+      // Best effort: remove any partial temp files (deletes the temp mp4 and
+      // its json sibling). The staging copy remains, so the video is still
+      // reviewable and reconcileStaging will retry on the next startup.
+      await deleteVideoDisk(tmpMp4);
+    }
+
+    done();
+  }
+
+  /**
    * Push kill video encoding progress to the frontend.
    */
   private onKillVideoProgress(progress: number) {
@@ -519,6 +689,13 @@ export default class VideoProcessQueue {
    */
   private static errorKillVideo(err: unknown) {
     console.error('[VideoProcessQueue] Error creating kill video', String(err));
+  }
+
+  /**
+   * Log an error relocating a video.
+   */
+  private static errorRelocatingVideo(err: unknown) {
+    console.error('[VideoProcessQueue] Error relocating video', String(err));
   }
 
   /**
@@ -658,6 +835,13 @@ export default class VideoProcessQueue {
    */
   private async uploadQueueEmpty() {
     console.info('[VideoProcessQueue] Upload processing queue empty');
+  }
+
+  /**
+   * Run actions on the relocate queue being empty.
+   */
+  private async relocateQueueEmpty() {
+    console.info('[VideoProcessQueue] Relocate processing queue empty');
   }
 
   /**

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -715,6 +715,13 @@ export default class VideoProcessQueue {
 
       console.info('[VideoProcessQueue] Relocated video to storage', destMp4);
 
+      // Tell the frontend the source moved staging -> storage so any open
+      // player swaps its reference to the permanent copy (and the relocating
+      // badge clears). Combined with the vod:// storage fallback, this makes
+      // the cutover seamless: the live media keeps streaming while state
+      // catches up to the permanent path.
+      send('videoSourceRelocated', { from: stagingPath, to: destMp4 });
+
       // Refresh so the frontend now resolves the video from storage. Any
       // in-progress playback of the local staging copy is unaffected.
       DiskClient.getInstance().refreshVideos();

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -13,6 +13,7 @@ import {
   KillVideoQueueItem,
   KillVideoStatus,
   RelocateQueueItem,
+  RelocateStatus,
   RendererVideo,
   SaveStatus,
   UploadQueueItem,
@@ -127,6 +128,12 @@ export default class VideoProcessQueue {
    * processing, or in progress currently.
    */
   private inProgressKillVideos: string[] = [];
+
+  /**
+   * Count of videos currently queued or in-flight for relocation to storage.
+   * Drives the queued count on the relocate progress indicator.
+   */
+  private inProgressRelocations = 0;
 
   /**
    * Resolved paths of the video sources currently loaded in the frontend
@@ -315,8 +322,24 @@ export default class VideoProcessQueue {
       '[VideoProcessQueue] Queuing video for relocation',
       item.stagingPath,
     );
+
+    this.inProgressRelocations += 1;
     this.relocateQueue.write(item);
+
+    // Surface the newly queued relocation (perc 0) so the indicator appears
+    // promptly, even before the copy of the current item makes progress.
+    this.emitRelocateStatus(0);
   };
+
+  /**
+   * Push the current relocation status to the frontend. perc is the copy
+   * progress of the in-flight item (0-100), or -1 for an indeterminate state.
+   */
+  private emitRelocateStatus(perc: number) {
+    const queued = Math.max(0, this.inProgressRelocations);
+    const status: RelocateStatus = { queued, perc };
+    send('updateRelocateStatus', status);
+  }
 
   /**
    * Reconcile the local staging dir on startup. For each staged video: if it
@@ -688,12 +711,66 @@ export default class VideoProcessQueue {
     const destMp4 = path.join(storageDir, name);
     const destJson = getMetadataFileNameForVideo(destMp4);
 
+    // Timer that watches the growing temp MP4 to report copy progress. It is a
+    // read-only observer (a periodic stat) running alongside the proven
+    // copyFile; it cannot affect the copy itself.
+    let progressTimer: ReturnType<typeof setInterval> | undefined;
+
     try {
       await fspromise.mkdir(tmpDir, { recursive: true });
 
-      // Copy both files fully into the temp dir (the slow network part).
+      // The JSON sidecar is tiny; copy it directly.
       await fspromise.copyFile(stagingJson, tmpJson);
+
+      // Source size is the denominator for progress. The MP4 is the slow
+      // (network) part, so we poll the temp file's size against this while
+      // copyFile runs.
+      const total = await fspromise
+        .stat(stagingPath)
+        .then((s) => s.size)
+        .catch(() => 0);
+
+      let lastPerc = -1;
+      let indeterminate = false;
+      let statInFlight = false;
+
+      progressTimer = setInterval(() => {
+        if (total <= 0 || statInFlight) {
+          return;
+        }
+
+        statInFlight = true;
+
+        fspromise
+          .stat(tmpMp4)
+          .then(({ size }) => {
+            const perc = Math.min(99, Math.round((size / total) * 100));
+
+            // If the very first observation is already "complete", the target
+            // likely preallocates the file rather than growing it; fall back to
+            // an indeterminate (activity-only) display instead of a fake bar.
+            if (lastPerc === -1 && size >= total) {
+              indeterminate = true;
+            }
+
+            if (perc !== lastPerc) {
+              lastPerc = perc;
+              this.emitRelocateStatus(indeterminate ? -1 : perc);
+            }
+          })
+          .catch(() => {
+            // Temp file not created yet, or a transient stat error; ignore.
+          })
+          .finally(() => {
+            statInFlight = false;
+          });
+      }, 300);
+
+      // Copy the MP4 into the temp dir (the slow network part).
       await fspromise.copyFile(stagingPath, tmpMp4);
+
+      clearInterval(progressTimer);
+      progressTimer = undefined;
 
       // Sanity check the copied video size matches the source.
       const [srcStat, dstStat] = await Promise.all([
@@ -740,6 +817,15 @@ export default class VideoProcessQueue {
       // its json sibling). The staging copy remains, so the video is still
       // reviewable and reconcileStaging will retry on the next startup.
       await deleteVideoDisk(tmpMp4);
+    } finally {
+      if (progressTimer) {
+        clearInterval(progressTimer);
+      }
+
+      // This relocation is done (success or failure). Drop the queued count and
+      // push status so the indicator advances to the next item or hides.
+      this.inProgressRelocations = Math.max(0, this.inProgressRelocations - 1);
+      this.emitRelocateStatus(0);
     }
 
     done();
@@ -934,6 +1020,11 @@ export default class VideoProcessQueue {
    */
   private async relocateQueueEmpty() {
     console.info('[VideoProcessQueue] Relocate processing queue empty');
+
+    // Backstop: the queue is drained, so nothing is in flight. Reset the count
+    // and hide the indicator in case the per-item bookkeeping ever drifted.
+    this.inProgressRelocations = 0;
+    this.emitRelocateStatus(0);
   }
 
   /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,6 +36,7 @@ import DiskClient from 'storage/DiskClient';
 import Poller from 'utils/Poller';
 import Recorder from './Recorder';
 import AsyncQueue from 'utils/AsyncQueue';
+import VideoProcessQueue from './VideoProcessQueue';
 
 const logDir = setupApplicationLogging();
 const appVersion = app.getVersion();
@@ -238,6 +239,12 @@ const createWindow = async () => {
     // which may not reflect reality.
     const disk = DiskClient.getInstance();
     const cloud = CloudClient.getInstance();
+
+    // Reconcile the local staging dir before the first video refresh: relocate
+    // any videos orphaned by a previous unclean shutdown, and drop local copies
+    // that already made it to storage. Safe to run only at startup, before any
+    // review session could hold a staging file open.
+    await VideoProcessQueue.getInstance().reconcileStaging();
 
     await Promise.all([
       manager.refreshStatus(),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -51,7 +51,8 @@ export type Channels =
   | 'reconfigureOverlay'
   | 'reconfigureCloud'
   | 'getSensibleEncoderDefault'
-  | 'refreshCloudGuilds';
+  | 'refreshCloudGuilds'
+  | 'activeVideoSources';
 
 contextBridge.exposeInMainWorld('electron', {
   ipcRenderer: {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -195,6 +195,17 @@ type RelocateQueueItem = {
 };
 
 /**
+ * Status of the background relocation of cut videos from the local staging dir
+ * to storage. Drives the small progress bar under the top-left status. perc is
+ * 0-100, or -1 to indicate an indeterminate (activity-only) state when the copy
+ * target doesn't expose progressive size growth.
+ */
+type RelocateStatus = {
+  queued: number;
+  perc: number;
+};
+
+/**
  * This is what we write to the .json files. We use "raw" subtypes here to
  * represent any classes as writing entire classes to JSON files causes
  * problems on the frontend.
@@ -748,4 +759,5 @@ export {
   KillVideoQueueItem,
   KillVideoSegment,
   KillVideoStatus,
+  RelocateStatus,
 };

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -185,6 +185,16 @@ type VideoQueueItem = {
 };
 
 /**
+ * An item on the relocate queue. Used by the "review locally while relocating
+ * to storage" feature to copy a freshly cut MP4 (and its metadata) from the
+ * local staging dir to the final storage path in the background.
+ */
+type RelocateQueueItem = {
+  stagingPath: string; // Full path to the .mp4 in the local staging dir.
+  storageDir: string; // Final storage directory (e.g. the NAS).
+};
+
+/**
  * This is what we write to the .json files. We use "raw" subtypes here to
  * represent any classes as writing entire classes to JSON files causes
  * problems on the frontend.
@@ -273,6 +283,10 @@ type RendererVideo = Metadata & {
   isProtected: boolean;
   cloud: boolean;
   multiPov: RendererVideo[];
+
+  // True while this video is being served from the local staging dir and is
+  // still being relocated to the final storage path in the background.
+  relocating?: boolean;
 
   // Used by frontend to uniquely identify a video, as videoName
   // is identical for a disk and cloud viewpoint.
@@ -681,6 +695,7 @@ export {
   FileInfo,
   FileFinderCallbackType,
   VideoQueueItem,
+  RelocateQueueItem,
   Metadata,
   RendererVideo,
   Flavour,

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -240,7 +240,7 @@ type Metadata = {
   overrun: number;
   affixes?: number[];
   tag?: string;
-  annotations?: string; // serialized Excalidraw drawing elements (JSON string)
+  annotations?: string; // serialized time-keyed drawing record (see renderer/annotations.ts); legacy values are a bare Excalidraw element array
   delete?: boolean; // signals video should be deleted when possible
   uniqueHash?: string; // used for cloud video grouping
   bossPercent?: number;

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -219,6 +219,7 @@ type Metadata = {
   overrun: number;
   affixes?: number[];
   tag?: string;
+  annotations?: string; // serialized Excalidraw drawing elements (JSON string)
   delete?: boolean; // signals video should be deleted when possible
   uniqueHash?: string; // used for cloud video grouping
   bossPercent?: number;

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -88,6 +88,29 @@ export const resolveHtmlPath = getResolvedHtmlPath();
 /**
  * Return information about a file needed for various parts of the application
  */
+/**
+ * Hooks used by the storage metadata index (src/storage/MetadataIndex.ts) to
+ * stay coherent as videos are written and deleted. The index registers these
+ * via setStorageIndexHooks so that util does NOT import the index (which would
+ * create a circular import). They are no-ops until registered.
+ */
+type MetadataWriteHook = (
+  videoPath: string,
+  metadata: Metadata,
+) => void | Promise<void>;
+type VideoDeleteHook = (videoPath: string) => void;
+
+let metadataWriteHook: MetadataWriteHook | null = null;
+let videoDeleteHook: VideoDeleteHook | null = null;
+
+const setStorageIndexHooks = (
+  write: MetadataWriteHook,
+  del: VideoDeleteHook,
+) => {
+  metadataWriteHook = write;
+  videoDeleteHook = del;
+};
+
 export const getFileInfo = async (pathSpec: string): Promise<FileInfo> => {
   const filePath = path.resolve(pathSpec);
   const fstats = await fspromise.stat(filePath);
@@ -233,6 +256,11 @@ const deleteVideoDisk = async (videoPath: string) => {
     return false;
   }
 
+  // Evict from the metadata index now the video file is gone.
+  if (videoDeleteHook) {
+    videoDeleteHook(videoPath);
+  }
+
   const metadataPath = getMetadataFileNameForVideo(videoPath);
   const deletedJson = await tryUnlink(metadataPath);
 
@@ -303,6 +331,11 @@ const writeMetadataFile = async (videoPath: string, metadata: Metadata) => {
   await fspromise.writeFile(metadataFileName, jsonString, {
     encoding: 'utf-8',
   });
+
+  // Keep the metadata index coherent with this write.
+  if (metadataWriteHook) {
+    await metadataWriteHook(videoPath, metadata);
+  }
 };
 
 /**
@@ -1241,6 +1274,7 @@ export {
   setupApplicationLogging,
   writeMetadataFile,
   deleteVideoDisk,
+  setStorageIndexHooks,
   openSystemExplorer,
   fixPathWhenPackaged,
   getSortedVideos,

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -41,6 +41,7 @@ import {
   secToMmSs,
 } from 'renderer/rendererutils';
 import { ZipArchive } from 'archiver';
+import { getStagingDir } from 'utils/configUtils';
 
 /**
  * When packaged, we need to fix some paths
@@ -1079,6 +1080,39 @@ const logAxiosError = (msg: string, error: AxiosError) => {
 };
 
 /**
+ * If the given path points at a local staging copy (the "review while
+ * relocating" feature), return the equivalent permanent storage path, else
+ * null. The staging and storage copies are byte-identical, so this lets the
+ * vod:// handler transparently fall back to the storage copy when a staging
+ * file is removed mid-playback after its relocation completes. This is what
+ * keeps seeking and playback seamless across the relocation cutover.
+ */
+const resolveRelocatedStoragePath = (filePath: string): string | null => {
+  const cfg = ConfigService.getInstance();
+  const stagingDir = getStagingDir(cfg);
+
+  if (!stagingDir) {
+    return null;
+  }
+
+  const resolved = path.resolve(filePath);
+  const resolvedStaging = path.resolve(stagingDir);
+
+  if (!resolved.startsWith(resolvedStaging + path.sep)) {
+    // Not a staging path; nothing to fall back to.
+    return null;
+  }
+
+  const storageDir = cfg.get<string>('storagePath');
+
+  if (!storageDir) {
+    return null;
+  }
+
+  return path.join(storageDir, path.basename(filePath));
+};
+
+/**
  * Custom protocol that enables the frontend to request MP4 files from disk.
  */
 const handleSafeVodRequest = async (request: Request) => {
@@ -1095,7 +1129,7 @@ const handleSafeVodRequest = async (request: Request) => {
       });
     }
 
-    const filePath = Buffer.from(requestUrl).toString('utf-8').split('#')[0]; // Remove any timestamps, the frontend handles those.
+    let filePath = Buffer.from(requestUrl).toString('utf-8').split('#')[0]; // Remove any timestamps, the frontend handles those.
 
     if (!filePath.endsWith('.mp4')) {
       console.error('[Util] Not an MP4 file:', filePath);
@@ -1112,12 +1146,37 @@ const handleSafeVodRequest = async (request: Request) => {
       // This will throw if the file doesn't exist.
       stats = await fspromise.stat(filePath);
     } catch (err) {
-      console.error('[Util] Error stating file:', err, filePath);
+      // The staging copy may have just been relocated to permanent storage
+      // and deleted out from under an open player. Transparently fall back to
+      // the (byte-identical) storage copy so seeking/playback don't break.
+      const fallback = resolveRelocatedStoragePath(filePath);
 
-      return new Response('', {
-        status: 404,
-        statusText: 'File Not Found',
-      });
+      if (fallback) {
+        try {
+          stats = await fspromise.stat(fallback);
+
+          console.info(
+            '[Util] Staging file gone, serving relocated storage copy',
+            fallback,
+          );
+
+          filePath = fallback;
+        } catch {
+          console.error('[Util] Error stating file:', err, filePath);
+
+          return new Response('', {
+            status: 404,
+            statusText: 'File Not Found',
+          });
+        }
+      } else {
+        console.error('[Util] Error stating file:', err, filePath);
+
+        return new Response('', {
+          status: 404,
+          statusText: 'File Not Found',
+        });
+      }
     }
 
     const fileSize = stats.size;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -299,6 +299,30 @@ const WarcraftRecorder = () => {
     });
   };
 
+  // A local staging copy ("review while relocating") has finished moving to
+  // permanent storage. Swap any references from the staging path to the
+  // storage path so the selected/listed videos track the permanent file and
+  // the relocating badge clears. The currently-playing media keeps streaming
+  // seamlessly via the vod:// storage fallback, so this is non-disruptive;
+  // updating selectedVideos also re-reports the active source to main so the
+  // staging copy can be cleaned up promptly.
+  const videoSourceRelocated = (payload: unknown) => {
+    const { from, to } = payload as { from: string; to: string };
+    const fromName = from.split(/[\\/]/).pop();
+
+    const swap = (v: RendererVideo): RendererVideo =>
+      !v.cloud && v.videoSource.split(/[\\/]/).pop() === fromName
+        ? { ...v, videoSource: to, relocating: false }
+        : v;
+
+    setVideoState((prev) => prev.map(swap));
+
+    setAppState((prevState) => ({
+      ...prevState,
+      selectedVideos: prevState.selectedVideos.map(swap),
+    }));
+  };
+
   // Incrementally add a new cloud video to the frontend, or update
   // it if it exists already.
   const displayAddCloudVideo = (video: unknown) => {
@@ -433,6 +457,7 @@ const WarcraftRecorder = () => {
     ipc.on('playAudio', playAudio);
     ipc.on('setCloudVideos', setCloudVideos);
     ipc.on('setDiskVideos', setDiskVideos);
+    ipc.on('videoSourceRelocated', videoSourceRelocated);
     ipc.on('displayAddCloudVideo', displayAddCloudVideo);
     ipc.on('displayRemoveCloudVideos', displayRemoveCloudVideos);
     ipc.on('displayProtectCloudVideos', displayProtectCloudVideos);
@@ -452,6 +477,7 @@ const WarcraftRecorder = () => {
       ipc.removeAllListeners('playAudio');
       ipc.removeAllListeners('setCloudVideos');
       ipc.removeAllListeners('setDiskVideos');
+      ipc.removeAllListeners('videoSourceRelocated');
       ipc.removeAllListeners('displayAddCloudVideo');
       ipc.removeAllListeners('displayRemoveCloudVideos');
       ipc.removeAllListeners('displayProtectCloudVideos');

--- a/src/renderer/RelocateProgress.tsx
+++ b/src/renderer/RelocateProgress.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { RelocateStatus } from 'main/types';
+import Progress from 'renderer/components/Progress/Progress';
+import { cn } from 'renderer/components/utils';
+
+const ipc = window.electron.ipcRenderer;
+
+/**
+ * A slim, gentle progress bar that appears beneath the top-left status while a
+ * freshly cut VOD is being moved out of the local buffer to permanent storage
+ * (the "review while relocating" feature). Self-contained: it listens to the
+ * 'updateRelocateStatus' channel and hides itself when nothing is in flight.
+ *
+ * perc < 0 indicates an indeterminate state (the copy target doesn't expose
+ * progressive size growth), shown as a gently pulsing full bar.
+ */
+const RelocateProgress = () => {
+  const [status, setStatus] = useState<RelocateStatus>({ perc: 0, queued: 0 });
+
+  useEffect(() => {
+    const handler = (s: unknown) => setStatus(s as RelocateStatus);
+    ipc.on('updateRelocateStatus', handler);
+
+    return () => {
+      ipc.removeAllListeners('updateRelocateStatus');
+    };
+  }, []);
+
+  if (status.queued < 1) {
+    return null;
+  }
+
+  const indeterminate = status.perc < 0;
+
+  const label =
+    status.queued > 1
+      ? `Moving to storage (+${status.queued - 1})`
+      : 'Moving to storage';
+
+  return (
+    <div className="mt-1 w-40 max-w-full flex flex-col gap-y-0.5 animate-in fade-in duration-300">
+      <span className="text-foreground-lighter text-[10px] font-semibold opacity-60">
+        {label}
+      </span>
+      <Progress
+        value={indeterminate ? 100 : status.perc}
+        className={cn(
+          'h-1 rounded-full',
+          indeterminate && 'animate-pulse opacity-60',
+        )}
+      />
+    </div>
+  );
+};
+
+export default RelocateProgress;

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -215,7 +215,89 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   const [muted, setMuted] = useState<boolean>(videoPlayerSettings.muted);
 
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
-  const [, setDrawingElements] = useState<readonly ExcalidrawElement[]>([]);
+
+  // Parse any persisted annotations stored on the primary video's metadata.
+  // Annotations are a JSON-serialized array of Excalidraw elements.
+  const parseAnnotations = (): readonly ExcalidrawElement[] => {
+    const raw = videos[0]?.annotations;
+    if (!raw) return [];
+
+    try {
+      return JSON.parse(raw) as ExcalidrawElement[];
+    } catch {
+      console.error('Failed to parse stored annotations');
+      return [];
+    }
+  };
+
+  // Live drawing elements. Held in a ref (not state) to avoid re-rendering the
+  // whole player on every stroke. Seeded once from the persisted annotations and
+  // used to re-seed the overlay when drawing mode is toggled off and back on.
+  const drawingElementsRef = useRef<readonly ExcalidrawElement[] | null>(null);
+
+  if (drawingElementsRef.current === null) {
+    drawingElementsRef.current = parseAnnotations();
+  }
+
+  // The last serialized scene we persisted, used to skip redundant writes.
+  const lastSavedAnnotationsRef = useRef<string>('');
+
+  // Excalidraw fires onChange once on mount echoing the seeded scene. We use the
+  // first event to establish a normalized baseline rather than persisting it.
+  const annotationsInitRef = useRef<boolean>(false);
+
+  // Debounce timer for persisting annotations.
+  const annotationsSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  /**
+   * Handle a change to the drawing overlay. Persists the serialized elements to
+   * the primary video's metadata on disk, debounced, and only when changed.
+   */
+  const onDrawingChange = useCallback(
+    (elements: readonly ExcalidrawElement[]) => {
+      drawingElementsRef.current = elements;
+      const serialized = JSON.stringify(elements);
+
+      if (!annotationsInitRef.current) {
+        // First event after mount is Excalidraw echoing the seeded scene.
+        // Record it as the baseline; don't persist.
+        annotationsInitRef.current = true;
+        lastSavedAnnotationsRef.current = serialized;
+        return;
+      }
+
+      if (serialized === lastSavedAnnotationsRef.current) {
+        // Nothing meaningful changed (e.g. selection / pointer move).
+        return;
+      }
+
+      lastSavedAnnotationsRef.current = serialized;
+
+      if (annotationsSaveTimer.current) {
+        clearTimeout(annotationsSaveTimer.current);
+      }
+
+      annotationsSaveTimer.current = setTimeout(() => {
+        ipc.sendMessage('videoButtonDisk', [
+          'annotations',
+          serialized,
+          [videos[0]],
+        ]);
+      }, 500);
+    },
+    [videos],
+  );
+
+  // Flush any pending annotation save when unmounting.
+  useEffect(() => {
+    return () => {
+      if (annotationsSaveTimer.current) {
+        clearTimeout(annotationsSaveTimer.current);
+      }
+    };
+  }, []);
 
   /**
    * Set if the video is playing or not.
@@ -1355,8 +1437,9 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       <div className="absolute top-0 left-0 w-full h-full">
         <DrawingOverlay
           isDrawingEnabled={isDrawingEnabled}
-          onDrawingChange={setDrawingElements}
+          onDrawingChange={onDrawingChange}
           appState={appState}
+          initialElements={drawingElementsRef.current ?? []}
         />
       </div>
     );

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -215,7 +215,89 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   const [muted, setMuted] = useState<boolean>(videoPlayerSettings.muted);
 
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
-  const [, setDrawingElements] = useState<readonly ExcalidrawElement[]>([]);
+
+  // Parse any persisted annotations stored on the primary video's metadata.
+  // Annotations are a JSON-serialized array of Excalidraw elements.
+  const parseAnnotations = (): readonly ExcalidrawElement[] => {
+    const raw = videos[0]?.annotations;
+    if (!raw) return [];
+
+    try {
+      return JSON.parse(raw) as ExcalidrawElement[];
+    } catch {
+      console.error('Failed to parse stored annotations');
+      return [];
+    }
+  };
+
+  // Live drawing elements. Held in a ref (not state) to avoid re-rendering the
+  // whole player on every stroke. Seeded once from the persisted annotations and
+  // used to re-seed the overlay when drawing mode is toggled off and back on.
+  const drawingElementsRef = useRef<readonly ExcalidrawElement[] | null>(null);
+
+  if (drawingElementsRef.current === null) {
+    drawingElementsRef.current = parseAnnotations();
+  }
+
+  // The last serialized scene we persisted, used to skip redundant writes.
+  const lastSavedAnnotationsRef = useRef<string>('');
+
+  // Excalidraw fires onChange once on mount echoing the seeded scene. We use the
+  // first event to establish a normalized baseline rather than persisting it.
+  const annotationsInitRef = useRef<boolean>(false);
+
+  // Debounce timer for persisting annotations.
+  const annotationsSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  /**
+   * Handle a change to the drawing overlay. Persists the serialized elements to
+   * the primary video's metadata on disk, debounced, and only when changed.
+   */
+  const onDrawingChange = useCallback(
+    (elements: readonly ExcalidrawElement[]) => {
+      drawingElementsRef.current = elements;
+      const serialized = JSON.stringify(elements);
+
+      if (!annotationsInitRef.current) {
+        // First event after mount is Excalidraw echoing the seeded scene.
+        // Record it as the baseline; don't persist.
+        annotationsInitRef.current = true;
+        lastSavedAnnotationsRef.current = serialized;
+        return;
+      }
+
+      if (serialized === lastSavedAnnotationsRef.current) {
+        // Nothing meaningful changed (e.g. selection / pointer move).
+        return;
+      }
+
+      lastSavedAnnotationsRef.current = serialized;
+
+      if (annotationsSaveTimer.current) {
+        clearTimeout(annotationsSaveTimer.current);
+      }
+
+      annotationsSaveTimer.current = setTimeout(() => {
+        ipc.sendMessage('videoButtonDisk', [
+          'annotations',
+          serialized,
+          [videos[0]],
+        ]);
+      }, 500);
+    },
+    [videos],
+  );
+
+  // Flush any pending annotation save when unmounting.
+  useEffect(() => {
+    return () => {
+      if (annotationsSaveTimer.current) {
+        clearTimeout(annotationsSaveTimer.current);
+      }
+    };
+  }, []);
 
   /**
    * Set if the video is playing or not.
@@ -1356,8 +1438,9 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       <div className="absolute top-0 left-0 w-full h-full">
         <DrawingOverlay
           isDrawingEnabled={isDrawingEnabled}
-          onDrawingChange={setDrawingElements}
+          onDrawingChange={onDrawingChange}
           appState={appState}
+          initialElements={drawingElementsRef.current ?? []}
         />
       </div>
     );

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -1414,6 +1414,18 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     ipc.sendMessage('videoPlayerSettings', ['set', soundSettings]);
   }, [volume, muted]);
 
+  // Tell the main process which video sources are currently loaded in the
+  // player. This lets the staging relocation logic avoid deleting a local
+  // staging copy that's being reviewed, and clean it up once playback moves on.
+  useEffect(() => {
+    const sources = videos.map((v) => v.videoSource);
+    ipc.sendMessage('activeVideoSources', sources);
+
+    return () => {
+      ipc.sendMessage('activeVideoSources', []);
+    };
+  }, [videos]);
+
   // Used to pause when the app is minimized to the system tray.
   useEffect(() => {
     ipc.on('pausePlayer', () => setPlaying(false));

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -216,10 +216,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
 
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
 
-  // Parse any persisted annotations stored on the primary video's metadata.
-  // Annotations are a JSON-serialized array of Excalidraw elements.
-  const parseAnnotations = (): readonly ExcalidrawElement[] => {
-    const raw = videos[0]?.annotations;
+  // Parse a serialized Excalidraw scene (JSON array of elements).
+  const parseAnnotations = (
+    raw: string | null | undefined,
+  ): readonly ExcalidrawElement[] => {
     if (!raw) return [];
 
     try {
@@ -230,13 +230,15 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     }
   };
 
-  // Live drawing elements. Held in a ref (not state) to avoid re-rendering the
-  // whole player on every stroke. Seeded once from the persisted annotations and
-  // used to re-seed the overlay when drawing mode is toggled off and back on.
-  const drawingElementsRef = useRef<readonly ExcalidrawElement[] | null>(null);
+  // Latest drawing scene as a serialized string. Seeded from the primary video's
+  // persisted annotations and updated on every change. We deliberately keep the
+  // *serialized* form rather than Excalidraw's live element array (which it
+  // mutates/empties on unmount), so the overlay can be re-seeded with fresh
+  // element objects when drawing mode is toggled off and back on.
+  const liveAnnotationsRef = useRef<string | null>(null);
 
-  if (drawingElementsRef.current === null) {
-    drawingElementsRef.current = parseAnnotations();
+  if (liveAnnotationsRef.current === null) {
+    liveAnnotationsRef.current = videos[0]?.annotations ?? '[]';
   }
 
   // The last serialized scene we persisted, used to skip redundant writes.
@@ -257,8 +259,8 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
    */
   const onDrawingChange = useCallback(
     (elements: readonly ExcalidrawElement[]) => {
-      drawingElementsRef.current = elements;
       const serialized = JSON.stringify(elements);
+      liveAnnotationsRef.current = serialized;
 
       if (!annotationsInitRef.current) {
         // First event after mount is Excalidraw echoing the seeded scene.
@@ -1452,7 +1454,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
           isDrawingEnabled={isDrawingEnabled}
           onDrawingChange={onDrawingChange}
           appState={appState}
-          initialElements={drawingElementsRef.current ?? []}
+          initialElements={parseAnnotations(liveAnnotationsRef.current)}
         />
       </div>
     );

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -51,10 +51,27 @@ import { DrawingOverlay } from './components/DrawingOverlay/DrawingOverlay';
 import {
   CloudDownload,
   CloudUpload,
+  Eraser,
   FolderOpen,
   Link,
   Pencil,
 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/Dialog/Dialog';
+import {
+  Keyframe,
+  activeFlashKeyframe,
+  keyframeTimes,
+  parseKeyframes,
+  serializeKeyframes,
+  upsertKeyframe,
+} from './annotations';
 import CloudIcon from '@mui/icons-material/Cloud';
 import SaveIcon from '@mui/icons-material/Save';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -216,37 +233,26 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
 
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
 
-  // Parse a serialized Excalidraw scene (JSON array of elements).
-  const parseAnnotations = (
-    raw: string | null | undefined,
-  ): readonly ExcalidrawElement[] => {
-    if (!raw) return [];
+  // VOD markup is a time-ordered list of keyframes (see ./annotations). The ref
+  // is the authoritative live copy; we mirror just the keyframe *times* into
+  // state to drive the timeline markers without re-rendering on every stroke.
+  const keyframesRef = useRef<Keyframe[] | null>(null);
 
-    try {
-      return JSON.parse(raw) as ExcalidrawElement[];
-    } catch {
-      console.error('Failed to parse stored annotations');
-      return [];
-    }
-  };
-
-  // Latest drawing scene as a serialized string. Seeded from the primary video's
-  // persisted annotations and updated on every change. We deliberately keep the
-  // *serialized* form rather than Excalidraw's live element array (which it
-  // mutates/empties on unmount), so the overlay can be re-seeded with fresh
-  // element objects when drawing mode is toggled off and back on.
-  const liveAnnotationsRef = useRef<string | null>(null);
-
-  if (liveAnnotationsRef.current === null) {
-    liveAnnotationsRef.current = videos[0]?.annotations ?? '[]';
+  if (keyframesRef.current === null) {
+    keyframesRef.current = parseKeyframes(videos[0]?.annotations);
   }
 
-  // The last serialized scene we persisted, used to skip redundant writes.
-  const lastSavedAnnotationsRef = useRef<string>('');
+  const [keyframeMarks, setKeyframeMarks] = useState<number[]>(() =>
+    keyframeTimes(keyframesRef.current ?? []),
+  );
 
-  // Excalidraw fires onChange once on mount echoing the seeded scene. We use the
-  // first event to establish a normalized baseline rather than persisting it.
-  const annotationsInitRef = useRef<boolean>(false);
+  // Confirmation dialog for the destructive "clear all" control.
+  const [clearDialogOpen, setClearDialogOpen] = useState<boolean>(false);
+
+  // The last serialized record we persisted, used to skip redundant writes.
+  const lastSavedAnnotationsRef = useRef<string>(
+    serializeKeyframes(keyframesRef.current ?? []),
+  );
 
   // Debounce timer for persisting annotations.
   const annotationsSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
@@ -254,51 +260,112 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   );
 
   /**
-   * Handle a change to the drawing overlay. Persists the serialized elements to
-   * the primary video's metadata on disk, debounced, and only when changed.
+   * Persist the current keyframe record to the primary video's metadata on
+   * disk, debounced, and only when it actually changed.
    */
-  const onDrawingChange = useCallback(
-    (elements: readonly ExcalidrawElement[]) => {
-      const serialized = JSON.stringify(elements);
-      liveAnnotationsRef.current = serialized;
+  const persistKeyframes = useCallback(() => {
+    // Coalesce rapid edits: the whole-record serialize and disk write happen at
+    // most once per quiet period, inside the debounced callback, rather than on
+    // every onChange.
+    if (annotationsSaveTimer.current) {
+      clearTimeout(annotationsSaveTimer.current);
+    }
 
-      if (!annotationsInitRef.current) {
-        // First event after mount is Excalidraw echoing the seeded scene.
-        // Record it as the baseline; don't persist.
-        annotationsInitRef.current = true;
-        lastSavedAnnotationsRef.current = serialized;
-        return;
-      }
+    annotationsSaveTimer.current = setTimeout(() => {
+      const serialized = serializeKeyframes(keyframesRef.current ?? []);
 
       if (serialized === lastSavedAnnotationsRef.current) {
-        // Nothing meaningful changed (e.g. selection / pointer move).
         return;
       }
 
       lastSavedAnnotationsRef.current = serialized;
 
-      if (annotationsSaveTimer.current) {
-        clearTimeout(annotationsSaveTimer.current);
+      ipc.sendMessage('videoButtonDisk', [
+        'annotations',
+        serialized,
+        [videos[0]],
+      ]);
+    }, 500);
+  }, [videos]);
+
+  /**
+   * Handle a change to the drawing overlay (edit mode only). Snapshots the full
+   * scene into the keyframe at the current edit time, then persists. Erasing a
+   * moment's drawing entirely removes that keyframe.
+   */
+  const onDrawingChange = useCallback(
+    (elements: readonly ExcalidrawElement[]) => {
+      const current = keyframesRef.current ?? [];
+
+      // Snapshot to the keyframe currently shown at the playhead (refining it),
+      // or to a new keyframe at the playhead if none is visible. Using the live
+      // playhead means edits land on the exact moment you're looking at.
+      const now = player1.current?.currentTime ?? 0;
+      const active = activeFlashKeyframe(current, now);
+      const t = active ? active.t : now;
+
+      // Change-detect against only the affected keyframe, not the whole record,
+      // so this stays cheap with many keyframes. onChange fires many times per
+      // second while a stroke is being drawn.
+      const incoming = JSON.stringify(elements);
+      const existing = active ? JSON.stringify(active.elements) : '[]';
+
+      if (incoming === existing) {
+        // Nothing meaningful changed for this keyframe (selection move, etc.).
+        return;
       }
 
-      annotationsSaveTimer.current = setTimeout(() => {
+      const next = upsertKeyframe(current, t, elements);
+      keyframesRef.current = next;
+
+      const times = keyframeTimes(next);
+      setKeyframeMarks((prev) =>
+        prev.length === times.length && prev.every((v, i) => v === times[i])
+          ? prev
+          : times,
+      );
+
+      persistKeyframes();
+    },
+    [persistKeyframes],
+  );
+
+  /**
+   * Wipe the entire annotation record for this VOD.
+   */
+  const clearAnnotations = useCallback(() => {
+    keyframesRef.current = [];
+    setKeyframeMarks([]);
+    persistKeyframes();
+    setClearDialogOpen(false);
+  }, [persistKeyframes]);
+
+  // Flush any pending annotation save when unmounting (e.g. the user switches
+  // VOD/POV within the debounce window). The player remounts on any such switch,
+  // so this closure's keyframesRef and videos[0] still both belong to THIS VOD —
+  // we write the final edits to the correct file rather than dropping them.
+  useEffect(() => {
+    return () => {
+      if (!annotationsSaveTimer.current) {
+        return;
+      }
+
+      clearTimeout(annotationsSaveTimer.current);
+      annotationsSaveTimer.current = null;
+
+      const serialized = serializeKeyframes(keyframesRef.current ?? []);
+
+      if (serialized !== lastSavedAnnotationsRef.current) {
+        lastSavedAnnotationsRef.current = serialized;
         ipc.sendMessage('videoButtonDisk', [
           'annotations',
           serialized,
           [videos[0]],
         ]);
-      }, 500);
-    },
-    [videos],
-  );
-
-  // Flush any pending annotation save when unmounting.
-  useEffect(() => {
-    return () => {
-      if (annotationsSaveTimer.current) {
-        clearTimeout(annotationsSaveTimer.current);
       }
     };
+    // videos[0] is stable for this instance's lifetime (a switch remounts), so
+    // the empty dep list is correct — we want the teardown of THIS mount only.
   }, []);
 
   /**
@@ -343,24 +410,51 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
    * Get the video timeline markers appropriate for the current video and
    * configuration.
    */
+  /**
+   * Return a slider marker for an annotation keyframe at the given time.
+   */
+  const getAnnotationMark = (time: number): SliderMark => {
+    return {
+      value: time,
+      label: (
+        <Tooltip content="Annotation">
+          <Box
+            sx={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '9999px',
+              backgroundColor: '#bb4420',
+              border: '1px solid rgba(0,0,0,0.4)',
+            }}
+          />
+        </Tooltip>
+      ),
+    };
+  };
+
   const getMarks = () => {
     const marks: SliderMark[] = [];
 
-    if (duration === 0 || isClip(videos[0])) {
+    if (duration === 0) {
       return marks;
     }
 
-    const deathMarkerConfig = convertNumToDeathMarkers(config.deathMarkers);
+    if (!isClip(videos[0])) {
+      const deathMarkerConfig = convertNumToDeathMarkers(config.deathMarkers);
 
-    if (deathMarkerConfig === DeathMarkers.ALL) {
-      getAllDeathMarkers(videos[0], language)
-        .map(getDeathMark)
-        .forEach((m) => marks.push(m));
-    } else if (deathMarkerConfig === DeathMarkers.OWN) {
-      getOwnDeathMarkers(videos[0], language)
-        .map(getDeathMark)
-        .forEach((m) => marks.push(m));
+      if (deathMarkerConfig === DeathMarkers.ALL) {
+        getAllDeathMarkers(videos[0], language)
+          .map(getDeathMark)
+          .forEach((m) => marks.push(m));
+      } else if (deathMarkerConfig === DeathMarkers.OWN) {
+        getOwnDeathMarkers(videos[0], language)
+          .map(getDeathMark)
+          .forEach((m) => marks.push(m));
+      }
     }
+
+    // Keyframe markers make the time-indexed nature of the markup visible.
+    keyframeMarks.forEach((t) => marks.push(getAnnotationMark(t)));
 
     return marks;
   };
@@ -1308,6 +1402,55 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   );
 
   /**
+   * Returns the "clear all annotations" button. Disabled when there is nothing
+   * to clear; opens a confirmation dialog as the action is destructive.
+   */
+  const renderClearAnnotationsButton = () => {
+    const hasAnnotations = keyframeMarks.length > 0;
+
+    return (
+      <Tooltip content="Clear all annotations">
+        <div>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setClearDialogOpen(true)}
+            disabled={!hasAnnotations}
+          >
+            <Eraser
+              size={20}
+              color={hasAnnotations ? 'white' : 'rgba(255,255,255,0.35)'}
+            />
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  };
+
+  /**
+   * Confirmation dialog for clearing the whole annotation record.
+   */
+  const renderClearAnnotationsDialog = () => (
+    <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Clear all annotations?</DialogTitle>
+          <DialogDescription>
+            This permanently removes every drawing keyframe from this VOD. This
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setClearDialogOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={clearAnnotations}>Clear all</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
+  /**
    * Returns the entire video control component.
    */
   const renderControls = () => {
@@ -1329,6 +1472,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
         {!multiPlayerMode && !clipMode && renderGetLinkButton()}
         <Separator className="mx-2" orientation="vertical" />
         {renderDrawingButton()}
+        {renderClearAnnotationsButton()}
         {!clipMode && !isClip(videos[0]) && renderClipButton()}
         {!multiPlayerMode && !clipMode && (
           <Separator className="mx-2" orientation="vertical" />
@@ -1447,13 +1591,28 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   }
 
   const renderDrawingOverlay = () => {
+    const keyframes = keyframesRef.current ?? [];
+    const mode: 'edit' | 'view' = isDrawingEnabled ? 'edit' : 'view';
+
+    // Existing markup flashes near its timestamp in BOTH modes, so it keeps
+    // displaying as you pan around the timeline even while drawing. Edit mode
+    // simply makes the shown keyframe interactive; the canvas re-seeds only when
+    // the active keyframe actually changes (so a paused stroke is never wiped).
+    const active = activeFlashKeyframe(keyframes, progress);
+    const elements = active ? active.elements : [];
+    const sceneKey = `${mode}:${active ? active.t.toFixed(2) : 'none'}`;
+
     return (
-      <div className="absolute top-0 left-0 w-full h-full">
+      <div
+        className="absolute top-0 left-0 w-full h-full"
+        style={{ pointerEvents: isDrawingEnabled ? 'auto' : 'none' }}
+      >
         <DrawingOverlay
-          isDrawingEnabled={isDrawingEnabled}
+          mode={mode}
+          elements={elements}
+          sceneKey={sceneKey}
           onDrawingChange={onDrawingChange}
           appState={appState}
-          initialElements={parseAnnotations(liveAnnotationsRef.current)}
         />
       </div>
     );
@@ -1483,12 +1642,14 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       <div style={{ height: 'calc(100% - 40px)' }}>
         <div className="w-full h-full relative">
           <div className={playerDivClass}>{srcs.map(renderPlayer)}</div>
-          {isDrawingEnabled && renderDrawingOverlay()}
+          {(isDrawingEnabled || keyframeMarks.length > 0) &&
+            renderDrawingOverlay()}
           {renderLoadingSpinner()}
         </div>
       </div>
 
       {renderControls()}
+      {renderClearAnnotationsDialog()}
     </div>
   );
 });

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -75,10 +75,11 @@ import {
   FLASH_WINDOW_MAX_SECONDS,
   FLASH_WINDOW_MIN_SECONDS,
   FLASH_WINDOW_SECONDS,
+  AnnotationRef,
   Keyframe,
   activeFlashKeyframe,
   keyframeTimes,
-  parseKeyframes,
+  parseAnnotations,
   serializeKeyframes,
   upsertKeyframe,
 } from './annotations';
@@ -268,9 +269,42 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   // state to drive the timeline markers without re-rendering on every stroke.
   const keyframesRef = useRef<Keyframe[] | null>(null);
 
+  // The capture resolution the keyframe coords are expressed in. Authoritative
+  // copy for serialization closures; mirrored into state below so the overlay
+  // re-renders once it becomes known. Null until a stored ref is loaded or the
+  // video's intrinsic size is captured (see captureRefResolution).
+  const refResolutionRef = useRef<AnnotationRef | null>(null);
+
   if (keyframesRef.current === null) {
-    keyframesRef.current = parseKeyframes(videos[0]?.annotations);
+    const parsed = parseAnnotations(videos[0]?.annotations);
+    keyframesRef.current = parsed.keyframes;
+    refResolutionRef.current = parsed.ref;
   }
+
+  // Mirror of refResolutionRef for rendering the overlay (which needs the ref to
+  // compute its zoom). Starts from any stored ref; filled in on metadata load.
+  const [refResolution, setRefResolution] = useState<AnnotationRef | null>(
+    () => refResolutionRef.current,
+  );
+
+  // Capture the primary video's intrinsic (capture) resolution as the reference
+  // space for NEW annotation records. No-op once a ref is known (stored records
+  // keep their original ref; the live size matches it for the same file anyway).
+  const captureRefResolution = useCallback(() => {
+    if (refResolutionRef.current) {
+      return;
+    }
+
+    const v = player1.current;
+
+    if (!v || !v.videoWidth || !v.videoHeight) {
+      return;
+    }
+
+    const ref = { w: v.videoWidth, h: v.videoHeight };
+    refResolutionRef.current = ref;
+    setRefResolution(ref);
+  }, []);
 
   const [keyframeMarks, setKeyframeMarks] = useState<number[]>(() =>
     keyframeTimes(keyframesRef.current ?? []),
@@ -281,7 +315,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
 
   // The last serialized record we persisted, used to skip redundant writes.
   const lastSavedAnnotationsRef = useRef<string>(
-    serializeKeyframes(keyframesRef.current ?? []),
+    serializeKeyframes(keyframesRef.current ?? [], refResolutionRef.current),
   );
 
   // Debounce timer for persisting annotations.
@@ -302,7 +336,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     }
 
     annotationsSaveTimer.current = setTimeout(() => {
-      const serialized = serializeKeyframes(keyframesRef.current ?? []);
+      const serialized = serializeKeyframes(
+        keyframesRef.current ?? [],
+        refResolutionRef.current,
+      );
 
       if (serialized === lastSavedAnnotationsRef.current) {
         return;
@@ -389,7 +426,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       clearTimeout(annotationsSaveTimer.current);
       annotationsSaveTimer.current = null;
 
-      const serialized = serializeKeyframes(keyframesRef.current ?? []);
+      const serialized = serializeKeyframes(
+        keyframesRef.current ?? [],
+        refResolutionRef.current,
+      );
 
       if (serialized !== lastSavedAnnotationsRef.current) {
         lastSavedAnnotationsRef.current = serialized;
@@ -734,6 +774,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     if (!player1.current || Number.isNaN(player1.current.duration)) {
       return;
     }
+
+    // Metadata is loaded by now, so the intrinsic frame size is available —
+    // capture it as the reference space for new annotation records.
+    captureRefResolution();
 
     persistentProgress.current = player1.current.currentTime;
     setDuration(player1.current.duration);
@@ -1694,6 +1738,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
           mode={mode}
           elements={elements}
           sceneKey={sceneKey}
+          refResolution={refResolution}
           onDrawingChange={onDrawingChange}
           appState={appState}
         />

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -51,10 +51,27 @@ import { DrawingOverlay } from './components/DrawingOverlay/DrawingOverlay';
 import {
   CloudDownload,
   CloudUpload,
+  Eraser,
   FolderOpen,
   Link,
   Pencil,
 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './components/Dialog/Dialog';
+import {
+  Keyframe,
+  activeFlashKeyframe,
+  keyframeTimes,
+  parseKeyframes,
+  serializeKeyframes,
+  upsertKeyframe,
+} from './annotations';
 import CloudIcon from '@mui/icons-material/Cloud';
 import SaveIcon from '@mui/icons-material/Save';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -216,37 +233,26 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
 
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
 
-  // Parse a serialized Excalidraw scene (JSON array of elements).
-  const parseAnnotations = (
-    raw: string | null | undefined,
-  ): readonly ExcalidrawElement[] => {
-    if (!raw) return [];
+  // VOD markup is a time-ordered list of keyframes (see ./annotations). The ref
+  // is the authoritative live copy; we mirror just the keyframe *times* into
+  // state to drive the timeline markers without re-rendering on every stroke.
+  const keyframesRef = useRef<Keyframe[] | null>(null);
 
-    try {
-      return JSON.parse(raw) as ExcalidrawElement[];
-    } catch {
-      console.error('Failed to parse stored annotations');
-      return [];
-    }
-  };
-
-  // Latest drawing scene as a serialized string. Seeded from the primary video's
-  // persisted annotations and updated on every change. We deliberately keep the
-  // *serialized* form rather than Excalidraw's live element array (which it
-  // mutates/empties on unmount), so the overlay can be re-seeded with fresh
-  // element objects when drawing mode is toggled off and back on.
-  const liveAnnotationsRef = useRef<string | null>(null);
-
-  if (liveAnnotationsRef.current === null) {
-    liveAnnotationsRef.current = videos[0]?.annotations ?? '[]';
+  if (keyframesRef.current === null) {
+    keyframesRef.current = parseKeyframes(videos[0]?.annotations);
   }
 
-  // The last serialized scene we persisted, used to skip redundant writes.
-  const lastSavedAnnotationsRef = useRef<string>('');
+  const [keyframeMarks, setKeyframeMarks] = useState<number[]>(() =>
+    keyframeTimes(keyframesRef.current ?? []),
+  );
 
-  // Excalidraw fires onChange once on mount echoing the seeded scene. We use the
-  // first event to establish a normalized baseline rather than persisting it.
-  const annotationsInitRef = useRef<boolean>(false);
+  // Confirmation dialog for the destructive "clear all" control.
+  const [clearDialogOpen, setClearDialogOpen] = useState<boolean>(false);
+
+  // The last serialized record we persisted, used to skip redundant writes.
+  const lastSavedAnnotationsRef = useRef<string>(
+    serializeKeyframes(keyframesRef.current ?? []),
+  );
 
   // Debounce timer for persisting annotations.
   const annotationsSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
@@ -254,51 +260,112 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   );
 
   /**
-   * Handle a change to the drawing overlay. Persists the serialized elements to
-   * the primary video's metadata on disk, debounced, and only when changed.
+   * Persist the current keyframe record to the primary video's metadata on
+   * disk, debounced, and only when it actually changed.
    */
-  const onDrawingChange = useCallback(
-    (elements: readonly ExcalidrawElement[]) => {
-      const serialized = JSON.stringify(elements);
-      liveAnnotationsRef.current = serialized;
+  const persistKeyframes = useCallback(() => {
+    // Coalesce rapid edits: the whole-record serialize and disk write happen at
+    // most once per quiet period, inside the debounced callback, rather than on
+    // every onChange.
+    if (annotationsSaveTimer.current) {
+      clearTimeout(annotationsSaveTimer.current);
+    }
 
-      if (!annotationsInitRef.current) {
-        // First event after mount is Excalidraw echoing the seeded scene.
-        // Record it as the baseline; don't persist.
-        annotationsInitRef.current = true;
-        lastSavedAnnotationsRef.current = serialized;
-        return;
-      }
+    annotationsSaveTimer.current = setTimeout(() => {
+      const serialized = serializeKeyframes(keyframesRef.current ?? []);
 
       if (serialized === lastSavedAnnotationsRef.current) {
-        // Nothing meaningful changed (e.g. selection / pointer move).
         return;
       }
 
       lastSavedAnnotationsRef.current = serialized;
 
-      if (annotationsSaveTimer.current) {
-        clearTimeout(annotationsSaveTimer.current);
+      ipc.sendMessage('videoButtonDisk', [
+        'annotations',
+        serialized,
+        [videos[0]],
+      ]);
+    }, 500);
+  }, [videos]);
+
+  /**
+   * Handle a change to the drawing overlay (edit mode only). Snapshots the full
+   * scene into the keyframe at the current edit time, then persists. Erasing a
+   * moment's drawing entirely removes that keyframe.
+   */
+  const onDrawingChange = useCallback(
+    (elements: readonly ExcalidrawElement[]) => {
+      const current = keyframesRef.current ?? [];
+
+      // Snapshot to the keyframe currently shown at the playhead (refining it),
+      // or to a new keyframe at the playhead if none is visible. Using the live
+      // playhead means edits land on the exact moment you're looking at.
+      const now = player1.current?.currentTime ?? 0;
+      const active = activeFlashKeyframe(current, now);
+      const t = active ? active.t : now;
+
+      // Change-detect against only the affected keyframe, not the whole record,
+      // so this stays cheap with many keyframes. onChange fires many times per
+      // second while a stroke is being drawn.
+      const incoming = JSON.stringify(elements);
+      const existing = active ? JSON.stringify(active.elements) : '[]';
+
+      if (incoming === existing) {
+        // Nothing meaningful changed for this keyframe (selection move, etc.).
+        return;
       }
 
-      annotationsSaveTimer.current = setTimeout(() => {
+      const next = upsertKeyframe(current, t, elements);
+      keyframesRef.current = next;
+
+      const times = keyframeTimes(next);
+      setKeyframeMarks((prev) =>
+        prev.length === times.length && prev.every((v, i) => v === times[i])
+          ? prev
+          : times,
+      );
+
+      persistKeyframes();
+    },
+    [persistKeyframes],
+  );
+
+  /**
+   * Wipe the entire annotation record for this VOD.
+   */
+  const clearAnnotations = useCallback(() => {
+    keyframesRef.current = [];
+    setKeyframeMarks([]);
+    persistKeyframes();
+    setClearDialogOpen(false);
+  }, [persistKeyframes]);
+
+  // Flush any pending annotation save when unmounting (e.g. the user switches
+  // VOD/POV within the debounce window). The player remounts on any such switch,
+  // so this closure's keyframesRef and videos[0] still both belong to THIS VOD —
+  // we write the final edits to the correct file rather than dropping them.
+  useEffect(() => {
+    return () => {
+      if (!annotationsSaveTimer.current) {
+        return;
+      }
+
+      clearTimeout(annotationsSaveTimer.current);
+      annotationsSaveTimer.current = null;
+
+      const serialized = serializeKeyframes(keyframesRef.current ?? []);
+
+      if (serialized !== lastSavedAnnotationsRef.current) {
+        lastSavedAnnotationsRef.current = serialized;
         ipc.sendMessage('videoButtonDisk', [
           'annotations',
           serialized,
           [videos[0]],
         ]);
-      }, 500);
-    },
-    [videos],
-  );
-
-  // Flush any pending annotation save when unmounting.
-  useEffect(() => {
-    return () => {
-      if (annotationsSaveTimer.current) {
-        clearTimeout(annotationsSaveTimer.current);
       }
     };
+    // videos[0] is stable for this instance's lifetime (a switch remounts), so
+    // the empty dep list is correct — we want the teardown of THIS mount only.
   }, []);
 
   /**
@@ -343,24 +410,51 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
    * Get the video timeline markers appropriate for the current video and
    * configuration.
    */
+  /**
+   * Return a slider marker for an annotation keyframe at the given time.
+   */
+  const getAnnotationMark = (time: number): SliderMark => {
+    return {
+      value: time,
+      label: (
+        <Tooltip content="Annotation">
+          <Box
+            sx={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '9999px',
+              backgroundColor: '#bb4420',
+              border: '1px solid rgba(0,0,0,0.4)',
+            }}
+          />
+        </Tooltip>
+      ),
+    };
+  };
+
   const getMarks = () => {
     const marks: SliderMark[] = [];
 
-    if (duration === 0 || isClip(videos[0])) {
+    if (duration === 0) {
       return marks;
     }
 
-    const deathMarkerConfig = convertNumToDeathMarkers(config.deathMarkers);
+    if (!isClip(videos[0])) {
+      const deathMarkerConfig = convertNumToDeathMarkers(config.deathMarkers);
 
-    if (deathMarkerConfig === DeathMarkers.ALL) {
-      getAllDeathMarkers(videos[0], language)
-        .map(getDeathMark)
-        .forEach((m) => marks.push(m));
-    } else if (deathMarkerConfig === DeathMarkers.OWN) {
-      getOwnDeathMarkers(videos[0], language)
-        .map(getDeathMark)
-        .forEach((m) => marks.push(m));
+      if (deathMarkerConfig === DeathMarkers.ALL) {
+        getAllDeathMarkers(videos[0], language)
+          .map(getDeathMark)
+          .forEach((m) => marks.push(m));
+      } else if (deathMarkerConfig === DeathMarkers.OWN) {
+        getOwnDeathMarkers(videos[0], language)
+          .map(getDeathMark)
+          .forEach((m) => marks.push(m));
+      }
     }
+
+    // Keyframe markers make the time-indexed nature of the markup visible.
+    keyframeMarks.forEach((t) => marks.push(getAnnotationMark(t)));
 
     return marks;
   };
@@ -1309,6 +1403,55 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   );
 
   /**
+   * Returns the "clear all annotations" button. Disabled when there is nothing
+   * to clear; opens a confirmation dialog as the action is destructive.
+   */
+  const renderClearAnnotationsButton = () => {
+    const hasAnnotations = keyframeMarks.length > 0;
+
+    return (
+      <Tooltip content="Clear all annotations">
+        <div>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => setClearDialogOpen(true)}
+            disabled={!hasAnnotations}
+          >
+            <Eraser
+              size={20}
+              color={hasAnnotations ? 'white' : 'rgba(255,255,255,0.35)'}
+            />
+          </Button>
+        </div>
+      </Tooltip>
+    );
+  };
+
+  /**
+   * Confirmation dialog for clearing the whole annotation record.
+   */
+  const renderClearAnnotationsDialog = () => (
+    <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Clear all annotations?</DialogTitle>
+          <DialogDescription>
+            This permanently removes every drawing keyframe from this VOD. This
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setClearDialogOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={clearAnnotations}>Clear all</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
+  /**
    * Returns the entire video control component.
    */
   const renderControls = () => {
@@ -1330,6 +1473,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
         {!multiPlayerMode && !clipMode && renderGetLinkButton()}
         <Separator className="mx-2" orientation="vertical" />
         {renderDrawingButton()}
+        {renderClearAnnotationsButton()}
         {!clipMode && !isClip(videos[0]) && renderClipButton()}
         {!multiPlayerMode && !clipMode && (
           <Separator className="mx-2" orientation="vertical" />
@@ -1448,13 +1592,28 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   }
 
   const renderDrawingOverlay = () => {
+    const keyframes = keyframesRef.current ?? [];
+    const mode: 'edit' | 'view' = isDrawingEnabled ? 'edit' : 'view';
+
+    // Existing markup flashes near its timestamp in BOTH modes, so it keeps
+    // displaying as you pan around the timeline even while drawing. Edit mode
+    // simply makes the shown keyframe interactive; the canvas re-seeds only when
+    // the active keyframe actually changes (so a paused stroke is never wiped).
+    const active = activeFlashKeyframe(keyframes, progress);
+    const elements = active ? active.elements : [];
+    const sceneKey = `${mode}:${active ? active.t.toFixed(2) : 'none'}`;
+
     return (
-      <div className="absolute top-0 left-0 w-full h-full">
+      <div
+        className="absolute top-0 left-0 w-full h-full"
+        style={{ pointerEvents: isDrawingEnabled ? 'auto' : 'none' }}
+      >
         <DrawingOverlay
-          isDrawingEnabled={isDrawingEnabled}
+          mode={mode}
+          elements={elements}
+          sceneKey={sceneKey}
           onDrawingChange={onDrawingChange}
           appState={appState}
-          initialElements={parseAnnotations(liveAnnotationsRef.current)}
         />
       </div>
     );
@@ -1484,12 +1643,14 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       <div style={{ height: 'calc(100% - 40px)' }}>
         <div className="w-full h-full relative">
           <div className={playerDivClass}>{srcs.map(renderPlayer)}</div>
-          {isDrawingEnabled && renderDrawingOverlay()}
+          {(isDrawingEnabled || keyframeMarks.length > 0) &&
+            renderDrawingOverlay()}
           {renderLoadingSpinner()}
         </div>
       </div>
 
       {renderControls()}
+      {renderClearAnnotationsDialog()}
     </div>
   );
 });

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -216,10 +216,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
 
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
 
-  // Parse any persisted annotations stored on the primary video's metadata.
-  // Annotations are a JSON-serialized array of Excalidraw elements.
-  const parseAnnotations = (): readonly ExcalidrawElement[] => {
-    const raw = videos[0]?.annotations;
+  // Parse a serialized Excalidraw scene (JSON array of elements).
+  const parseAnnotations = (
+    raw: string | null | undefined,
+  ): readonly ExcalidrawElement[] => {
     if (!raw) return [];
 
     try {
@@ -230,13 +230,15 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     }
   };
 
-  // Live drawing elements. Held in a ref (not state) to avoid re-rendering the
-  // whole player on every stroke. Seeded once from the persisted annotations and
-  // used to re-seed the overlay when drawing mode is toggled off and back on.
-  const drawingElementsRef = useRef<readonly ExcalidrawElement[] | null>(null);
+  // Latest drawing scene as a serialized string. Seeded from the primary video's
+  // persisted annotations and updated on every change. We deliberately keep the
+  // *serialized* form rather than Excalidraw's live element array (which it
+  // mutates/empties on unmount), so the overlay can be re-seeded with fresh
+  // element objects when drawing mode is toggled off and back on.
+  const liveAnnotationsRef = useRef<string | null>(null);
 
-  if (drawingElementsRef.current === null) {
-    drawingElementsRef.current = parseAnnotations();
+  if (liveAnnotationsRef.current === null) {
+    liveAnnotationsRef.current = videos[0]?.annotations ?? '[]';
   }
 
   // The last serialized scene we persisted, used to skip redundant writes.
@@ -257,8 +259,8 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
    */
   const onDrawingChange = useCallback(
     (elements: readonly ExcalidrawElement[]) => {
-      drawingElementsRef.current = elements;
       const serialized = JSON.stringify(elements);
+      liveAnnotationsRef.current = serialized;
 
       if (!annotationsInitRef.current) {
         // First event after mount is Excalidraw echoing the seeded scene.
@@ -1451,7 +1453,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
           isDrawingEnabled={isDrawingEnabled}
           onDrawingChange={onDrawingChange}
           appState={appState}
-          initialElements={drawingElementsRef.current ?? []}
+          initialElements={parseAnnotations(liveAnnotationsRef.current)}
         />
       </div>
     );

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -31,6 +31,7 @@ import DoneIcon from '@mui/icons-material/Done';
 import ReactPlayer from 'react-player';
 import screenfull from 'screenfull';
 import { ConfigurationSchema } from 'config/configSchema';
+import { setConfigValue } from './useSettings';
 import { getLocalePhrase } from 'localisation/translations';
 import DeathIcon from '../../assets/icon/death.png';
 import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
@@ -55,6 +56,7 @@ import {
   FolderOpen,
   Link,
   Pencil,
+  Timer,
 } from 'lucide-react';
 import {
   Dialog,
@@ -65,6 +67,14 @@ import {
   DialogTitle,
 } from './components/Dialog/Dialog';
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from './components/Popover/Popover';
+import {
+  FLASH_WINDOW_MAX_SECONDS,
+  FLASH_WINDOW_MIN_SECONDS,
+  FLASH_WINDOW_SECONDS,
   Keyframe,
   activeFlashKeyframe,
   keyframeTimes,
@@ -231,6 +241,26 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   const [volume, setVolume] = useState<number>(videoPlayerSettings.volume);
   const [muted, setMuted] = useState<boolean>(videoPlayerSettings.muted);
 
+  // How long (seconds) an annotation keyframe stays shown during playback.
+  // User-adjustable via the duration slider; applies live to existing
+  // annotations. Clamped in case of a stale stored value.
+  const [flashWindow, setFlashWindow] = useState<number>(() =>
+    Math.min(
+      FLASH_WINDOW_MAX_SECONDS,
+      Math.max(
+        FLASH_WINDOW_MIN_SECONDS,
+        config.annotationFlashSeconds ?? FLASH_WINDOW_SECONDS,
+      ),
+    ),
+  );
+
+  // Mirror into a ref so the memoized change handler reads the latest value.
+  const flashWindowRef = useRef<number>(flashWindow);
+
+  useEffect(() => {
+    flashWindowRef.current = flashWindow;
+  }, [flashWindow]);
+
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
 
   // VOD markup is a time-ordered list of keyframes (see ./annotations). The ref
@@ -301,13 +331,19 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       // or to a new keyframe at the playhead if none is visible. Using the live
       // playhead means edits land on the exact moment you're looking at.
       const now = player1.current?.currentTime ?? 0;
-      const active = activeFlashKeyframe(current, now);
+      const active = activeFlashKeyframe(current, now, flashWindowRef.current);
       const t = active ? active.t : now;
+
+      // Excalidraw soft-deletes: the eraser marks elements isDeleted but keeps
+      // them in the array. Persist and compare only VISIBLE elements, so erasing
+      // a keyframe's contents empties it — and upsertKeyframe drops the now-empty
+      // keyframe — rather than leaving an invisible tombstone keyframe behind.
+      const visible = elements.filter((el) => !el.isDeleted);
 
       // Change-detect against only the affected keyframe, not the whole record,
       // so this stays cheap with many keyframes. onChange fires many times per
       // second while a stroke is being drawn.
-      const incoming = JSON.stringify(elements);
+      const incoming = JSON.stringify(visible);
       const existing = active ? JSON.stringify(active.elements) : '[]';
 
       if (incoming === existing) {
@@ -315,7 +351,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
         return;
       }
 
-      const next = upsertKeyframe(current, t, elements);
+      const next = upsertKeyframe(current, t, visible);
       keyframesRef.current = next;
 
       const times = keyframeTimes(next);
@@ -1451,6 +1487,49 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   );
 
   /**
+   * Returns the annotation display-duration control: a bounded slider (in a
+   * popover off a timer glyph) for how long a keyframe stays shown during
+   * playback. Changes apply live to existing annotations.
+   */
+  const renderAnnotationDurationControl = () => (
+    <Popover>
+      <Tooltip content="Annotation display duration">
+        <PopoverTrigger asChild>
+          <Button variant="ghost" size="xs">
+            <Timer size={20} color="white" />
+          </Button>
+        </PopoverTrigger>
+      </Tooltip>
+      <PopoverContent side="top" className="w-56">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between text-xs font-semibold text-foreground-lighter">
+            <span>Annotation duration</span>
+            <span className="tabular-nums">{flashWindow}s</span>
+          </div>
+          <Slider
+            size="small"
+            value={flashWindow}
+            min={FLASH_WINDOW_MIN_SECONDS}
+            max={FLASH_WINDOW_MAX_SECONDS}
+            step={1}
+            valueLabelDisplay="auto"
+            valueLabelFormat={(v) => `${v}s`}
+            onChange={(_event, v) => {
+              if (typeof v === 'number') setFlashWindow(v);
+            }}
+            onChangeCommitted={(_event, v) => {
+              // Persist once on release rather than on every drag tick.
+              if (typeof v === 'number') {
+                setConfigValue('annotationFlashSeconds', v);
+              }
+            }}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+
+  /**
    * Returns the entire video control component.
    */
   const renderControls = () => {
@@ -1471,8 +1550,11 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
         {!multiPlayerMode && !clipMode && renderOpenFolderButton()}
         {!multiPlayerMode && !clipMode && renderGetLinkButton()}
         <Separator className="mx-2" orientation="vertical" />
-        {renderDrawingButton()}
-        {renderClearAnnotationsButton()}
+        {!multiPlayerMode && renderDrawingButton()}
+        {!multiPlayerMode && renderClearAnnotationsButton()}
+        {!multiPlayerMode &&
+          (isDrawingEnabled || keyframeMarks.length > 0) &&
+          renderAnnotationDurationControl()}
         {!clipMode && !isClip(videos[0]) && renderClipButton()}
         {!multiPlayerMode && !clipMode && (
           <Separator className="mx-2" orientation="vertical" />
@@ -1598,7 +1680,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     // displaying as you pan around the timeline even while drawing. Edit mode
     // simply makes the shown keyframe interactive; the canvas re-seeds only when
     // the active keyframe actually changes (so a paused stroke is never wiped).
-    const active = activeFlashKeyframe(keyframes, progress);
+    const active = activeFlashKeyframe(keyframes, progress, flashWindow);
     const elements = active ? active.elements : [];
     const sceneKey = `${mode}:${active ? active.t.toFixed(2) : 'none'}`;
 
@@ -1642,7 +1724,8 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       <div style={{ height: 'calc(100% - 40px)' }}>
         <div className="w-full h-full relative">
           <div className={playerDivClass}>{srcs.map(renderPlayer)}</div>
-          {(isDrawingEnabled || keyframeMarks.length > 0) &&
+          {!multiPlayerMode &&
+            (isDrawingEnabled || keyframeMarks.length > 0) &&
             renderDrawingOverlay()}
           {renderLoadingSpinner()}
         </div>

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -31,6 +31,7 @@ import DoneIcon from '@mui/icons-material/Done';
 import ReactPlayer from 'react-player';
 import screenfull from 'screenfull';
 import { ConfigurationSchema } from 'config/configSchema';
+import { setConfigValue } from './useSettings';
 import { getLocalePhrase } from 'localisation/translations';
 import DeathIcon from '../../assets/icon/death.png';
 import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
@@ -55,6 +56,7 @@ import {
   FolderOpen,
   Link,
   Pencil,
+  Timer,
 } from 'lucide-react';
 import {
   Dialog,
@@ -65,6 +67,14 @@ import {
   DialogTitle,
 } from './components/Dialog/Dialog';
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from './components/Popover/Popover';
+import {
+  FLASH_WINDOW_MAX_SECONDS,
+  FLASH_WINDOW_MIN_SECONDS,
+  FLASH_WINDOW_SECONDS,
   Keyframe,
   activeFlashKeyframe,
   keyframeTimes,
@@ -231,6 +241,26 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   const [volume, setVolume] = useState<number>(videoPlayerSettings.volume);
   const [muted, setMuted] = useState<boolean>(videoPlayerSettings.muted);
 
+  // How long (seconds) an annotation keyframe stays shown during playback.
+  // User-adjustable via the duration slider; applies live to existing
+  // annotations. Clamped in case of a stale stored value.
+  const [flashWindow, setFlashWindow] = useState<number>(() =>
+    Math.min(
+      FLASH_WINDOW_MAX_SECONDS,
+      Math.max(
+        FLASH_WINDOW_MIN_SECONDS,
+        config.annotationFlashSeconds ?? FLASH_WINDOW_SECONDS,
+      ),
+    ),
+  );
+
+  // Mirror into a ref so the memoized change handler reads the latest value.
+  const flashWindowRef = useRef<number>(flashWindow);
+
+  useEffect(() => {
+    flashWindowRef.current = flashWindow;
+  }, [flashWindow]);
+
   const [isDrawingEnabled, setIsDrawingEnabled] = useState(false);
 
   // VOD markup is a time-ordered list of keyframes (see ./annotations). The ref
@@ -301,13 +331,19 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       // or to a new keyframe at the playhead if none is visible. Using the live
       // playhead means edits land on the exact moment you're looking at.
       const now = player1.current?.currentTime ?? 0;
-      const active = activeFlashKeyframe(current, now);
+      const active = activeFlashKeyframe(current, now, flashWindowRef.current);
       const t = active ? active.t : now;
+
+      // Excalidraw soft-deletes: the eraser marks elements isDeleted but keeps
+      // them in the array. Persist and compare only VISIBLE elements, so erasing
+      // a keyframe's contents empties it — and upsertKeyframe drops the now-empty
+      // keyframe — rather than leaving an invisible tombstone keyframe behind.
+      const visible = elements.filter((el) => !el.isDeleted);
 
       // Change-detect against only the affected keyframe, not the whole record,
       // so this stays cheap with many keyframes. onChange fires many times per
       // second while a stroke is being drawn.
-      const incoming = JSON.stringify(elements);
+      const incoming = JSON.stringify(visible);
       const existing = active ? JSON.stringify(active.elements) : '[]';
 
       if (incoming === existing) {
@@ -315,7 +351,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
         return;
       }
 
-      const next = upsertKeyframe(current, t, elements);
+      const next = upsertKeyframe(current, t, visible);
       keyframesRef.current = next;
 
       const times = keyframeTimes(next);
@@ -1452,6 +1488,49 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
   );
 
   /**
+   * Returns the annotation display-duration control: a bounded slider (in a
+   * popover off a timer glyph) for how long a keyframe stays shown during
+   * playback. Changes apply live to existing annotations.
+   */
+  const renderAnnotationDurationControl = () => (
+    <Popover>
+      <Tooltip content="Annotation display duration">
+        <PopoverTrigger asChild>
+          <Button variant="ghost" size="xs">
+            <Timer size={20} color="white" />
+          </Button>
+        </PopoverTrigger>
+      </Tooltip>
+      <PopoverContent side="top" className="w-56">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between text-xs font-semibold text-foreground-lighter">
+            <span>Annotation duration</span>
+            <span className="tabular-nums">{flashWindow}s</span>
+          </div>
+          <Slider
+            size="small"
+            value={flashWindow}
+            min={FLASH_WINDOW_MIN_SECONDS}
+            max={FLASH_WINDOW_MAX_SECONDS}
+            step={1}
+            valueLabelDisplay="auto"
+            valueLabelFormat={(v) => `${v}s`}
+            onChange={(_event, v) => {
+              if (typeof v === 'number') setFlashWindow(v);
+            }}
+            onChangeCommitted={(_event, v) => {
+              // Persist once on release rather than on every drag tick.
+              if (typeof v === 'number') {
+                setConfigValue('annotationFlashSeconds', v);
+              }
+            }}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+
+  /**
    * Returns the entire video control component.
    */
   const renderControls = () => {
@@ -1472,8 +1551,11 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
         {!multiPlayerMode && !clipMode && renderOpenFolderButton()}
         {!multiPlayerMode && !clipMode && renderGetLinkButton()}
         <Separator className="mx-2" orientation="vertical" />
-        {renderDrawingButton()}
-        {renderClearAnnotationsButton()}
+        {!multiPlayerMode && renderDrawingButton()}
+        {!multiPlayerMode && renderClearAnnotationsButton()}
+        {!multiPlayerMode &&
+          (isDrawingEnabled || keyframeMarks.length > 0) &&
+          renderAnnotationDurationControl()}
         {!clipMode && !isClip(videos[0]) && renderClipButton()}
         {!multiPlayerMode && !clipMode && (
           <Separator className="mx-2" orientation="vertical" />
@@ -1599,7 +1681,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     // displaying as you pan around the timeline even while drawing. Edit mode
     // simply makes the shown keyframe interactive; the canvas re-seeds only when
     // the active keyframe actually changes (so a paused stroke is never wiped).
-    const active = activeFlashKeyframe(keyframes, progress);
+    const active = activeFlashKeyframe(keyframes, progress, flashWindow);
     const elements = active ? active.elements : [];
     const sceneKey = `${mode}:${active ? active.t.toFixed(2) : 'none'}`;
 
@@ -1643,7 +1725,8 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
       <div style={{ height: 'calc(100% - 40px)' }}>
         <div className="w-full h-full relative">
           <div className={playerDivClass}>{srcs.map(renderPlayer)}</div>
-          {(isDrawingEnabled || keyframeMarks.length > 0) &&
+          {!multiPlayerMode &&
+            (isDrawingEnabled || keyframeMarks.length > 0) &&
             renderDrawingOverlay()}
           {renderLoadingSpinner()}
         </div>

--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -1413,6 +1413,18 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
     ipc.sendMessage('videoPlayerSettings', ['set', soundSettings]);
   }, [volume, muted]);
 
+  // Tell the main process which video sources are currently loaded in the
+  // player. This lets the staging relocation logic avoid deleting a local
+  // staging copy that's being reviewed, and clean it up once playback moves on.
+  useEffect(() => {
+    const sources = videos.map((v) => v.videoSource);
+    ipc.sendMessage('activeVideoSources', sources);
+
+    return () => {
+      ipc.sendMessage('activeVideoSources', []);
+    };
+  }, [videos]);
+
   // Used to pause when the app is minimized to the system tray.
   useEffect(() => {
     ipc.on('pausePlayer', () => setPlaying(false));

--- a/src/renderer/annotations.ts
+++ b/src/renderer/annotations.ts
@@ -1,0 +1,139 @@
+import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
+
+/**
+ * A single time-stamped snapshot of the drawing scene. `t` is the video
+ * position in seconds; `elements` is the full Excalidraw scene at that moment.
+ *
+ * VOD markup is stored as a time-ordered list of these keyframes rather than a
+ * single whole-VOD overlay, so annotations become a time-sensitive record:
+ * what you drew at 0:30 is distinct from what you drew at 2:10.
+ */
+export type Keyframe = {
+  t: number;
+  elements: ExcalidrawElement[];
+};
+
+type AnnotationRecord = {
+  version: 2;
+  keyframes: Keyframe[];
+};
+
+/**
+ * How long (seconds) a keyframe's drawing stays on screen during playback
+ * before it clears ("flash" display). The caller passes the live playhead,
+ * which freezes on pause, so a keyframe visible at the moment of pausing stays
+ * up until playback resumes and moves past the window.
+ */
+export const FLASH_WINDOW_SECONDS = 5;
+
+/**
+ * Edits within this many seconds of an existing keyframe update that keyframe
+ * in place rather than spawning a new one, so a burst of strokes at one spot
+ * doesn't fragment into many near-identical keyframes.
+ */
+export const KEYFRAME_MERGE_TOLERANCE_SECONDS = 0.75;
+
+const EMPTY: ExcalidrawElement[] = [];
+
+/**
+ * Parse the persisted annotation string into a sorted keyframe list. Accepts
+ * both the current keyframe-record format and the legacy single-scene format (a
+ * bare Excalidraw element array), which is migrated to one keyframe at t=0.
+ */
+export const parseKeyframes = (raw: string | null | undefined): Keyframe[] => {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const data = JSON.parse(raw);
+
+    if (Array.isArray(data)) {
+      // Legacy format: a bare element array applied to the whole VOD. Anchor it
+      // as a single keyframe at the start so old annotations still show.
+      return data.length
+        ? [{ t: 0, elements: data as ExcalidrawElement[] }]
+        : [];
+    }
+
+    if (data && Array.isArray(data.keyframes)) {
+      return (data.keyframes as Keyframe[])
+        .filter((k) => Array.isArray(k.elements) && k.elements.length > 0)
+        .map((k) => ({ t: Number(k.t) || 0, elements: k.elements }))
+        .sort((a, b) => a.t - b.t);
+    }
+  } catch {
+    console.error('[Annotations] Failed to parse stored annotations');
+  }
+
+  return [];
+};
+
+/**
+ * Serialize keyframes for persistence. Returns '[]' when there is nothing to
+ * keep, which the disk layer already treats as "clear annotations".
+ */
+export const serializeKeyframes = (keyframes: Keyframe[]): string => {
+  const nonEmpty = keyframes.filter((k) => k.elements.length > 0);
+
+  if (nonEmpty.length === 0) {
+    return '[]';
+  }
+
+  const record: AnnotationRecord = { version: 2, keyframes: nonEmpty };
+  return JSON.stringify(record);
+};
+
+/**
+ * Insert or update the keyframe at time `t` with `elements`. An existing
+ * keyframe within the merge tolerance is replaced; otherwise a new one is
+ * inserted (kept sorted by time). Empty `elements` removes the keyframe at that
+ * time, so erasing everything at a moment deletes that keyframe.
+ */
+export const upsertKeyframe = (
+  keyframes: Keyframe[],
+  t: number,
+  elements: readonly ExcalidrawElement[],
+): Keyframe[] => {
+  const next = keyframes.filter(
+    (k) => Math.abs(k.t - t) > KEYFRAME_MERGE_TOLERANCE_SECONDS,
+  );
+
+  if (elements.length > 0) {
+    next.push({ t, elements: [...elements] });
+  }
+
+  return next.sort((a, b) => a.t - b.t);
+};
+
+/**
+ * The keyframe at or just before `t`, but only while `t` is within the flash
+ * window after it; otherwise null. Yields "flash near the timestamp, then
+ * clear". Because the caller passes the live (freeze-on-pause) playhead, a
+ * keyframe visible when the user pauses stays visible.
+ */
+export const activeFlashKeyframe = (
+  keyframes: Keyframe[],
+  t: number,
+  windowSeconds = FLASH_WINDOW_SECONDS,
+): Keyframe | null => {
+  return keyframes.reduce<Keyframe | null>((best, k) => {
+    const inWindow = k.t <= t + 1e-3 && t - k.t <= windowSeconds;
+    if (!inWindow) return best;
+    return !best || k.t > best.t ? k : best;
+  }, null);
+};
+
+/** Convenience: elements of the active flash keyframe at `t`, or empty. */
+export const flashElementsAt = (
+  keyframes: Keyframe[],
+  t: number,
+  windowSeconds = FLASH_WINDOW_SECONDS,
+): ExcalidrawElement[] => {
+  const active = activeFlashKeyframe(keyframes, t, windowSeconds);
+  return active ? active.elements : EMPTY;
+};
+
+/** Times of all keyframes, for drawing timeline markers. */
+export const keyframeTimes = (keyframes: Keyframe[]): number[] =>
+  keyframes.map((k) => k.t);

--- a/src/renderer/annotations.ts
+++ b/src/renderer/annotations.ts
@@ -13,8 +13,30 @@ export type Keyframe = {
   elements: ExcalidrawElement[];
 };
 
+/**
+ * The video's capture resolution that a record's element coordinates are
+ * expressed in. Element coords live in this fixed reference space (Excalidraw
+ * "scene" units); on playback the overlay only changes `zoom` to map this space
+ * onto the live (resized/letterboxed) video rect — so the same coords render
+ * correctly at any window/frame size. See DrawingOverlay.
+ */
+export type AnnotationRef = { w: number; h: number };
+
+/**
+ * Persisted shape. `version: 3` records carry `ref` (resolution-independent).
+ * Legacy `version: 2` records and the even older bare-array format have no
+ * `ref`; their coords are in draw-time canvas pixels and load best-effort.
+ */
 type AnnotationRecord = {
-  version: 2;
+  version: 3;
+  ref?: AnnotationRef;
+  keyframes: Keyframe[];
+};
+
+/** Result of parsing a stored annotation string: the keyframes plus the
+ *  reference resolution their coords are in (null for legacy records). */
+export type ParsedAnnotations = {
+  ref: AnnotationRef | null;
   keyframes: Keyframe[];
 };
 
@@ -44,9 +66,11 @@ const EMPTY: ExcalidrawElement[] = [];
  * both the current keyframe-record format and the legacy single-scene format (a
  * bare Excalidraw element array), which is migrated to one keyframe at t=0.
  */
-export const parseKeyframes = (raw: string | null | undefined): Keyframe[] => {
+export const parseAnnotations = (
+  raw: string | null | undefined,
+): ParsedAnnotations => {
   if (!raw) {
-    return [];
+    return { ref: null, keyframes: [] };
   }
 
   try {
@@ -55,17 +79,20 @@ export const parseKeyframes = (raw: string | null | undefined): Keyframe[] => {
     if (Array.isArray(data)) {
       // Legacy format: a bare element array applied to the whole VOD. Anchor it
       // as a single keyframe at the start so old annotations still show. Drop
-      // soft-deleted (isDeleted) tombstones.
+      // soft-deleted (isDeleted) tombstones. No `ref` — pre-resolution-independent.
       const visible = (data as ExcalidrawElement[]).filter(
         (el) => !el.isDeleted,
       );
 
-      return visible.length ? [{ t: 0, elements: visible }] : [];
+      return {
+        ref: null,
+        keyframes: visible.length ? [{ t: 0, elements: visible }] : [],
+      };
     }
 
     if (data && Array.isArray(data.keyframes)) {
       // Drop soft-deleted tombstones, then drop any keyframe left empty.
-      return (data.keyframes as Keyframe[])
+      const keyframes = (data.keyframes as Keyframe[])
         .map((k) => ({
           t: Number(k.t) || 0,
           elements: Array.isArray(k.elements)
@@ -74,26 +101,52 @@ export const parseKeyframes = (raw: string | null | undefined): Keyframe[] => {
         }))
         .filter((k) => k.elements.length > 0)
         .sort((a, b) => a.t - b.t);
+
+      // `ref` is present from v3 on; v2 records lack it (legacy pixel coords).
+      const r = data.ref;
+      const ref =
+        r && Number(r.w) > 0 && Number(r.h) > 0
+          ? { w: Number(r.w), h: Number(r.h) }
+          : null;
+
+      return { ref, keyframes };
     }
   } catch {
     console.error('[Annotations] Failed to parse stored annotations');
   }
 
-  return [];
+  return { ref: null, keyframes: [] };
 };
 
 /**
- * Serialize keyframes for persistence. Returns '[]' when there is nothing to
- * keep, which the disk layer already treats as "clear annotations".
+ * Back-compat convenience: just the keyframes from a stored annotation string.
+ * Prefer `parseAnnotations` when the reference resolution is needed.
  */
-export const serializeKeyframes = (keyframes: Keyframe[]): string => {
+export const parseKeyframes = (raw: string | null | undefined): Keyframe[] =>
+  parseAnnotations(raw).keyframes;
+
+/**
+ * Serialize keyframes for persistence. Returns '[]' when there is nothing to
+ * keep, which the disk layer already treats as "clear annotations". `ref` (the
+ * capture resolution the coords are in) is written when known so the record is
+ * resolution-independent on reload.
+ */
+export const serializeKeyframes = (
+  keyframes: Keyframe[],
+  ref?: AnnotationRef | null,
+): string => {
   const nonEmpty = keyframes.filter((k) => k.elements.length > 0);
 
   if (nonEmpty.length === 0) {
     return '[]';
   }
 
-  const record: AnnotationRecord = { version: 2, keyframes: nonEmpty };
+  const record: AnnotationRecord = { version: 3, keyframes: nonEmpty };
+
+  if (ref && ref.w > 0 && ref.h > 0) {
+    record.ref = { w: ref.w, h: ref.h };
+  }
+
   return JSON.stringify(record);
 };
 

--- a/src/renderer/annotations.ts
+++ b/src/renderer/annotations.ts
@@ -26,6 +26,10 @@ type AnnotationRecord = {
  */
 export const FLASH_WINDOW_SECONDS = 5;
 
+/** Bounds for the user-adjustable flash window (the duration slider). */
+export const FLASH_WINDOW_MIN_SECONDS = 1;
+export const FLASH_WINDOW_MAX_SECONDS = 30;
+
 /**
  * Edits within this many seconds of an existing keyframe update that keyframe
  * in place rather than spawning a new one, so a burst of strokes at one spot
@@ -50,16 +54,25 @@ export const parseKeyframes = (raw: string | null | undefined): Keyframe[] => {
 
     if (Array.isArray(data)) {
       // Legacy format: a bare element array applied to the whole VOD. Anchor it
-      // as a single keyframe at the start so old annotations still show.
-      return data.length
-        ? [{ t: 0, elements: data as ExcalidrawElement[] }]
-        : [];
+      // as a single keyframe at the start so old annotations still show. Drop
+      // soft-deleted (isDeleted) tombstones.
+      const visible = (data as ExcalidrawElement[]).filter(
+        (el) => !el.isDeleted,
+      );
+
+      return visible.length ? [{ t: 0, elements: visible }] : [];
     }
 
     if (data && Array.isArray(data.keyframes)) {
+      // Drop soft-deleted tombstones, then drop any keyframe left empty.
       return (data.keyframes as Keyframe[])
-        .filter((k) => Array.isArray(k.elements) && k.elements.length > 0)
-        .map((k) => ({ t: Number(k.t) || 0, elements: k.elements }))
+        .map((k) => ({
+          t: Number(k.t) || 0,
+          elements: Array.isArray(k.elements)
+            ? k.elements.filter((el) => !el.isDeleted)
+            : [],
+        }))
+        .filter((k) => k.elements.length > 0)
         .sort((a, b) => a.t - b.t);
     }
   } catch {

--- a/src/renderer/components/DrawingOverlay/DrawingOverlay.css
+++ b/src/renderer/components/DrawingOverlay/DrawingOverlay.css
@@ -4,6 +4,17 @@
     background-color: transparent;
 }
 
+/* Excalidraw's dark theme runs every canvas through
+   `filter: invert(93%) hue-rotate(180deg)` so its light-mode scene looks right
+   on a dark UI. Over our transparent video overlay that just desaturates/shifts
+   the user's colours (pure red -> muted pink). Neutralise the theme filter
+   variable inside the overlay so strokes — and the colour-picker swatches /
+   eyedropper, which reference the same variable — render in true sRGB, while the
+   dark UI chrome (styled via colour tokens, not this filter) stays dark. */
+.drawing-overlay .excalidraw.theme--dark {
+    --theme-filter: none;
+}
+
 /* Hide only the main menu button */
 .excalidraw .main-menu-trigger {
     display: none !important;

--- a/src/renderer/components/DrawingOverlay/DrawingOverlay.css
+++ b/src/renderer/components/DrawingOverlay/DrawingOverlay.css
@@ -19,3 +19,9 @@
 .excalidraw .sidebar-trigger__label-element {
     display: none !important;
 }
+
+/* In read-only "view" mode (flash playback) hide all Excalidraw UI chrome so
+   only the drawing itself is shown over the video. */
+.drawing-overlay.view-mode .excalidraw .layer-ui__wrapper {
+    display: none !important;
+}

--- a/src/renderer/components/DrawingOverlay/DrawingOverlay.css
+++ b/src/renderer/components/DrawingOverlay/DrawingOverlay.css
@@ -1,10 +1,7 @@
+/* Layout (position/size) is set inline in DrawingOverlay.tsx so the canvas can
+   track the letterboxed video-content rect; keep only cosmetic rules here. */
 .drawing-overlay-content {
-    flex: 1;
     background-color: transparent;
-    position: relative;
-    pointer-events: auto;
-    width: 100%;
-    height: 100%;
 }
 
 /* Hide only the main menu button */

--- a/src/renderer/components/DrawingOverlay/DrawingOverlay.tsx
+++ b/src/renderer/components/DrawingOverlay/DrawingOverlay.tsx
@@ -1,11 +1,15 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Excalidraw } from '@excalidraw/excalidraw';
 import '@excalidraw/excalidraw/index.css';
 import './DrawingOverlay.css';
 import { AppState } from 'main/types';
 import { Language } from 'localisation/phrases';
 import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
-import { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/dist/types/excalidraw/types';
+import {
+  ExcalidrawImperativeAPI,
+  NormalizedZoomValue,
+} from '@excalidraw/excalidraw/dist/types/excalidraw/types';
+import { AnnotationRef } from '../../annotations';
 
 interface DrawingOverlayProps {
   // 'edit' is an interactive freedraw canvas; 'view' is a read-only display of
@@ -17,15 +21,61 @@ interface DrawingOverlayProps {
   // flip in view mode, or an edit-time change in edit mode). User edits do NOT
   // change it, so an in-progress drawing is never clobbered by a re-seed.
   sceneKey: string;
+  // The capture resolution element coords are expressed in. When set, the canvas
+  // is sized to the letterboxed video rect and zoomed so this reference space
+  // maps onto it — making annotations resolution-independent. Null for legacy
+  // records (or before metadata loads): falls back to 1:1 pixel behaviour.
+  refResolution: AnnotationRef | null;
   // Fired in edit mode when the user mutates the scene.
   onDrawingChange: (elements: readonly ExcalidrawElement[]) => void;
   appState: AppState;
 }
 
+type Rect = { left: number; top: number; width: number; height: number };
+
+/**
+ * The video-content rectangle within `box`, given the reference aspect ratio.
+ * The `<video>` letterboxes (preserves aspect) inside its cell, so annotations
+ * must map to this inner rect, not the whole cell. With no ref (legacy / pre-
+ * metadata) the rect is the full box and the caller uses zoom 1.
+ */
+const computeContentRect = (
+  box: { w: number; h: number },
+  ref: AnnotationRef | null,
+): Rect => {
+  if (!ref || ref.w <= 0 || ref.h <= 0 || box.w <= 0 || box.h <= 0) {
+    return { left: 0, top: 0, width: box.w, height: box.h };
+  }
+
+  const aspect = ref.w / ref.h;
+  const boxAspect = box.w / box.h;
+
+  let width: number;
+  let height: number;
+
+  if (boxAspect > aspect) {
+    // Box is wider than the video → pillarbox (bars on the left/right).
+    height = box.h;
+    width = box.h * aspect;
+  } else {
+    // Box is taller than the video → letterbox (bars on top/bottom).
+    width = box.w;
+    height = box.w / aspect;
+  }
+
+  return {
+    left: (box.w - width) / 2,
+    top: (box.h - height) / 2,
+    width,
+    height,
+  };
+};
+
 export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
   mode,
   elements,
   sceneKey,
+  refResolution,
   onDrawingChange,
   appState,
 }) => {
@@ -38,6 +88,36 @@ export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
   // mis-persisted (re-stamping seeded content at the wrong time -> moved /
   // merged / deleted keyframes). Only a change the user actually drew counts.
   const editedSinceSeedRef = useRef(false);
+
+  // Live pixel size of the overlay cell, tracked so the canvas follows window /
+  // frame resizes. Drives the letterboxed content rect and the Excalidraw zoom.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [box, setBox] = useState<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+
+    const ro = new ResizeObserver((entries) => {
+      const cr = entries[0]?.contentRect;
+      if (cr) setBox({ w: cr.width, h: cr.height });
+    });
+
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const rect = computeContentRect(box, refResolution);
+
+  // Map the reference space onto the content rect: a scene unit of `ref.w`
+  // spans `rect.width` px, so zoom = rect.width / ref.w (scroll stays 0). With
+  // no ref we keep zoom 1 (legacy 1:1 pixel behaviour). Excalidraw clamps zoom
+  // to [0.1, 30]; the floor only bites at an extreme downscale, which is fine.
+  const targetZoom = (
+    refResolution && refResolution.w > 0 && rect.width > 0
+      ? rect.width / refResolution.w
+      : 1
+  ) as NormalizedZoomValue;
 
   // Convert current language to a language code supported by Excalidraw
   const langCodeMap = {
@@ -62,18 +142,41 @@ export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
     editedSinceSeedRef.current = false;
   }, [sceneKey]);
 
+  // Keep the viewport locked to the reference space as the cell resizes. Only
+  // the appState transform is touched (not elements), so an in-progress stroke
+  // is never wiped; and since elements are unchanged, the onChange echo is a
+  // no-op for persistence even if it slips past editedSinceSeedRef.
+  useEffect(() => {
+    const api = apiRef.current;
+    if (!api) return;
+    api.updateScene({
+      appState: { zoom: { value: targetZoom }, scrollX: 0, scrollY: 0 },
+    });
+  }, [targetZoom]);
+
   return (
     <div
+      ref={containerRef}
       className={`drawing-overlay h-full w-full${viewMode ? ' view-mode' : ''}`}
+      style={{ position: 'relative' }}
       onKeyDown={(e) => {
         e.stopPropagation();
       }}
     >
       <div
         className="drawing-overlay-content"
-        // In view mode the overlay must not intercept clicks so the video and
-        // its controls stay usable while annotations are shown.
-        style={{ pointerEvents: viewMode ? 'none' : 'auto' }}
+        // Positioned/sized to the letterboxed video-content rect so annotations
+        // land on the video pixels, not the cell's letterbox bars.
+        style={{
+          position: 'absolute',
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
+          height: rect.height,
+          // In view mode the overlay must not intercept clicks so the video and
+          // its controls stay usable while annotations are shown.
+          pointerEvents: viewMode ? 'none' : 'auto',
+        }}
         // Capture phase so we record the interaction before Excalidraw handles
         // it. Marks subsequent onChange events as genuine user edits.
         onPointerDownCapture={() => {
@@ -100,6 +203,9 @@ export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
             elements: [...elements],
             appState: {
               viewBackgroundColor: 'transparent',
+              zoom: { value: targetZoom },
+              scrollX: 0,
+              scrollY: 0,
               activeTool: {
                 type: 'freedraw',
                 lastActiveTool: null,

--- a/src/renderer/components/DrawingOverlay/DrawingOverlay.tsx
+++ b/src/renderer/components/DrawingOverlay/DrawingOverlay.tsx
@@ -4,17 +4,20 @@ import '@excalidraw/excalidraw/index.css';
 import './DrawingOverlay.css';
 import { AppState } from 'main/types';
 import { Language } from 'localisation/phrases';
+import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
 
 interface DrawingOverlayProps {
   isDrawingEnabled: boolean;
-  onDrawingChange: (elements: readonly any[]) => void;
+  onDrawingChange: (elements: readonly ExcalidrawElement[]) => void;
   appState: AppState;
+  initialElements?: readonly ExcalidrawElement[];
 }
 
 export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
   isDrawingEnabled,
   onDrawingChange,
   appState,
+  initialElements = [],
 }) => {
   if (!isDrawingEnabled) return null;
 
@@ -46,6 +49,7 @@ export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
           onChange={(elements) => onDrawingChange(elements)}
           langCode={langCode}
           initialData={{
+            elements: initialElements,
             appState: {
               viewBackgroundColor: 'transparent',
               activeTool: {

--- a/src/renderer/components/DrawingOverlay/DrawingOverlay.tsx
+++ b/src/renderer/components/DrawingOverlay/DrawingOverlay.tsx
@@ -1,25 +1,43 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Excalidraw } from '@excalidraw/excalidraw';
 import '@excalidraw/excalidraw/index.css';
 import './DrawingOverlay.css';
 import { AppState } from 'main/types';
 import { Language } from 'localisation/phrases';
 import { ExcalidrawElement } from '@excalidraw/excalidraw/dist/types/excalidraw/element/types';
+import { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/dist/types/excalidraw/types';
 
 interface DrawingOverlayProps {
-  isDrawingEnabled: boolean;
+  // 'edit' is an interactive freedraw canvas; 'view' is a read-only display of
+  // the current keyframe, used for "flash" playback.
+  mode: 'edit' | 'view';
+  // The scene to show right now (the active keyframe's elements, or [] none).
+  elements: readonly ExcalidrawElement[];
+  // A token that changes only when the canvas should be re-seeded (a keyframe
+  // flip in view mode, or an edit-time change in edit mode). User edits do NOT
+  // change it, so an in-progress drawing is never clobbered by a re-seed.
+  sceneKey: string;
+  // Fired in edit mode when the user mutates the scene.
   onDrawingChange: (elements: readonly ExcalidrawElement[]) => void;
   appState: AppState;
-  initialElements?: readonly ExcalidrawElement[];
 }
 
 export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
-  isDrawingEnabled,
+  mode,
+  elements,
+  sceneKey,
   onDrawingChange,
   appState,
-  initialElements = [],
 }) => {
-  if (!isDrawingEnabled) return null;
+  const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
+  const viewMode = mode === 'view';
+
+  // True once the user has put a pointer down on the canvas since the last
+  // programmatic re-seed. Excalidraw fires onChange both for real edits AND as
+  // an echo of our own updateScene() calls; without this gate those echoes get
+  // mis-persisted (re-stamping seeded content at the wrong time -> moved /
+  // merged / deleted keyframes). Only a change the user actually drew counts.
+  const editedSinceSeedRef = useRef(false);
 
   // Convert current language to a language code supported by Excalidraw
   const langCodeMap = {
@@ -31,25 +49,55 @@ export const DrawingOverlay: React.FC<DrawingOverlayProps> = ({
 
   const langCode = langCodeMap[appState.language];
 
+  // Re-seed the live canvas whenever sceneKey changes (a keyframe flip or an
+  // edit-time change), without remounting Excalidraw. We depend on sceneKey
+  // rather than `elements` so the user's own in-progress edits don't trigger a
+  // re-seed that would wipe them.
+  useEffect(() => {
+    const api = apiRef.current;
+    if (!api) return;
+    api.updateScene({ elements: [...elements] });
+    // This scene came from us, not the user. Ignore the resulting onChange
+    // echo(es) until the user next interacts.
+    editedSinceSeedRef.current = false;
+  }, [sceneKey]);
+
   return (
     <div
-      className="drawing-overlay h-full w-full"
+      className={`drawing-overlay h-full w-full${viewMode ? ' view-mode' : ''}`}
       onKeyDown={(e) => {
         e.stopPropagation();
       }}
     >
-      <div className="drawing-overlay-content">
+      <div
+        className="drawing-overlay-content"
+        // In view mode the overlay must not intercept clicks so the video and
+        // its controls stay usable while annotations are shown.
+        style={{ pointerEvents: viewMode ? 'none' : 'auto' }}
+        // Capture phase so we record the interaction before Excalidraw handles
+        // it. Marks subsequent onChange events as genuine user edits.
+        onPointerDownCapture={() => {
+          if (!viewMode) editedSinceSeedRef.current = true;
+        }}
+      >
         <Excalidraw
           theme="dark"
           gridModeEnabled={false}
-          viewModeEnabled={false}
+          viewModeEnabled={viewMode}
           zenModeEnabled={false}
           name="Drawing Overlay"
-          key={langCode} // Add key to re-render component when language changes
-          onChange={(elements) => onDrawingChange(elements)}
+          key={langCode} // Re-render when language changes
+          excalidrawAPI={(api) => {
+            apiRef.current = api;
+          }}
+          onChange={(els) => {
+            if (viewMode) return;
+            if (!editedSinceSeedRef.current) return;
+            onDrawingChange(els);
+          }}
           langCode={langCode}
           initialData={{
-            elements: initialElements,
+            elements: [...elements],
             appState: {
               viewBackgroundColor: 'transparent',
               activeTool: {

--- a/src/renderer/containers/ApplicationStatusCard/Status.tsx
+++ b/src/renderer/containers/ApplicationStatusCard/Status.tsx
@@ -23,6 +23,7 @@ import StatusLight, {
 } from 'renderer/components/StatusLight/StatusLight';
 import { cn } from 'renderer/components/utils';
 import { secToMmSs } from 'renderer/rendererutils';
+import RelocateProgress from 'renderer/RelocateProgress';
 
 type StatusInfo = {
   statusTitle: string;
@@ -409,6 +410,7 @@ const Status = ({
                 <HardDriveDownload size={14} className="mx-1 animate-pulse" />
               )}
             </div>
+            <RelocateProgress />
           </div>
         </div>
         {!!statusDescription && (

--- a/src/renderer/useSettings.ts
+++ b/src/renderer/useSettings.ts
@@ -70,6 +70,7 @@ export const getSettings = (): ConfigurationSchema => {
     deathMarkers: getConfigValue<number>('deathMarkers'),
     encounterMarkers: getConfigValue<boolean>('encounterMarkers'),
     roundMarkers: getConfigValue<boolean>('roundMarkers'),
+    annotationFlashSeconds: getConfigValue<number>('annotationFlashSeconds'),
     pushToTalk: getConfigValue<boolean>('pushToTalk'),
     pushToTalkKey: getConfigValue<number>('pushToTalkKey'),
     pushToTalkMouseButton: getConfigValue<number>('pushToTalkMouseButton'),

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -180,8 +180,10 @@ export default class DiskClient implements StorageClient {
   }
 
   public async annotateVideos(videoPaths: string[], annotations: string) {
-    videoPaths.forEach((videoPath) =>
-      this.annotateVideoDisk(videoPath, annotations),
+    await Promise.all(
+      videoPaths.map((videoPath) =>
+        this.annotateVideoDisk(videoPath, annotations),
+      ),
     );
   }
 
@@ -327,7 +329,14 @@ export default class DiskClient implements StorageClient {
         const videos = args[2] as RendererVideo[];
         const disk = videos.filter((v) => !v.cloud);
         const toAnnotate = disk.map((v) => v.videoSource);
-        this.annotateVideos(toAnnotate, annotations);
+        await this.annotateVideos(toAnnotate, annotations);
+
+        // Refresh so the in-memory video state reflects the saved annotations.
+        // Without this, reopening the VOD later in the same session (which
+        // remounts the player and re-seeds from videos[0].annotations) would
+        // show an empty overlay. The currently-playing player isn't disrupted
+        // (its videos come from selectedVideos, and its key is unchanged).
+        this.refreshVideos();
       }
     });
   }

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -143,6 +143,12 @@ export default class DiskClient implements StorageClient {
     );
   }
 
+  public async annotateVideos(videoPaths: string[], annotations: string) {
+    videoPaths.forEach((videoPath) =>
+      this.annotateVideoDisk(videoPath, annotations),
+    );
+  }
+
   /**
    * Put a save marker on a video, protecting it from the file monitor.
    */
@@ -191,6 +197,32 @@ export default class DiskClient implements StorageClient {
     } else {
       console.info('[Util] User tagged', videoPath, 'with', tag);
       metadata.tag = tag;
+    }
+
+    await writeMetadataFile(videoPath, metadata);
+  }
+
+  private async annotateVideoDisk(videoPath: string, annotations: string) {
+    let metadata;
+
+    try {
+      metadata = await getMetadataForVideo(videoPath);
+    } catch (err) {
+      console.error(
+        `[Util] Metadata not found for '${videoPath}', but somehow we managed to load it. This shouldn't happen.`,
+        err,
+      );
+
+      return;
+    }
+
+    if (!annotations || annotations === '[]') {
+      // No elements; clear any existing annotations.
+      console.info('[Util] User cleared annotations on', videoPath);
+      metadata.annotations = undefined;
+    } else {
+      console.info('[Util] User annotated', videoPath);
+      metadata.annotations = annotations;
     }
 
     await writeMetadataFile(videoPath, metadata);
@@ -252,6 +284,14 @@ export default class DiskClient implements StorageClient {
         const disk = videos.filter((v) => !v.cloud);
         const toTag = disk.map((v) => v.videoSource);
         this.tagVideos(toTag, tag);
+      }
+
+      if (action === 'annotations') {
+        const annotations = args[1] as string;
+        const videos = args[2] as RendererVideo[];
+        const disk = videos.filter((v) => !v.cloud);
+        const toAnnotate = disk.map((v) => v.videoSource);
+        this.annotateVideos(toAnnotate, annotations);
       }
     });
   }

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -76,36 +76,45 @@ export default class DiskClient implements StorageClient {
   }
 
   /**
-   * Get the videos and set them on the frontend.
+   * Get the videos and set them on the frontend. Pass reconcile=false to
+   * rebuild the list straight from the in-memory metadata index WITHOUT
+   * re-scanning the storage dir — used after an annotation write, where the
+   * index write hook has already updated the affected entry (keyed by its own
+   * path) and no files were added or removed, so a storage round-trip is wasted.
    */
-  public async refreshVideos() {
-    const videos = await this.getVideos();
+  public async refreshVideos(reconcile = true) {
+    const videos = await this.getVideos(reconcile);
     send('setDiskVideos', videos);
   }
 
   /**
-   * Get the videos.
+   * Get the videos. When reconcile is false the storage dir is NOT re-scanned;
+   * the list is built from the in-memory index as-is.
    */
-  private async getVideos() {
-    const rdy = await this.ready();
-
-    if (!rdy) {
-      console.warn('[DiskClient] Not ready, no videos');
-      return [];
-    }
-
-    console.info('[DiskClient] Getting videos from disk');
-
+  private async getVideos(reconcile = true) {
     const cfg = ConfigService.getInstance();
     const storageDir = cfg.get<string>('storagePath');
     const stagingDir = getStagingDir(cfg);
-
-    // Reconcile the in-memory metadata index with the storage dir. This is
-    // delta-only: a single readdir, reading just the files new since last time.
-    // The bulk of refreshes (after a record/clip/delete) change nothing and so
-    // cost only the readdir, instead of re-stat'ing and re-parsing every video.
     const index = MetadataIndex.getInstance();
-    await index.reconcile(storageDir);
+
+    if (reconcile) {
+      const rdy = await this.ready();
+
+      if (!rdy) {
+        console.warn('[DiskClient] Not ready, no videos');
+        return [];
+      }
+
+      console.info('[DiskClient] Getting videos from disk');
+
+      // Reconcile the in-memory metadata index with the storage dir. This is
+      // delta-only: a single readdir, reading just the files new since last
+      // time. The bulk of refreshes (after a record/clip/delete) change nothing
+      // and so cost only the readdir, instead of re-stat'ing and re-parsing
+      // every video.
+      await index.reconcile(storageDir);
+    }
+
     const storageVideos = index.list();
 
     // When the "review locally while relocating" feature is active, also surface
@@ -336,7 +345,13 @@ export default class DiskClient implements StorageClient {
         // remounts the player and re-seeds from videos[0].annotations) would
         // show an empty overlay. The currently-playing player isn't disrupted
         // (its videos come from selectedVideos, and its key is unchanged).
-        this.refreshVideos();
+        //
+        // reconcile=false: annotateVideoDisk just wrote the metadata, which the
+        // index write hook already folded into this video's index entry. No
+        // files changed, so rebuild from the index without re-scanning storage
+        // (the storage dir is typically a NAS, so this skips a round-trip on
+        // every save).
+        this.refreshVideos(false);
       }
     });
   }

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -13,8 +13,9 @@ import {
   openSystemExplorer,
   writeMetadataFile,
 } from 'main/util';
-import { DiskStatus, FileInfo, RendererVideo } from 'main/types';
+import { DiskStatus, RendererVideo } from 'main/types';
 import DiskSizeMonitor from './DiskSizeMonitor';
+import MetadataIndex from './MetadataIndex';
 import { ipcMain } from 'electron';
 import assert from 'assert';
 import { send } from 'main/main';
@@ -39,6 +40,11 @@ export default class DiskClient implements StorageClient {
   private constructor() {
     console.info('[DiskClient] Creating disk client');
     this.setupListeners();
+
+    // Construct the metadata index now so its storage hooks
+    // (writeMetadataFile / deleteVideoDisk) are registered before any video is
+    // written, keeping the index coherent from the very first write.
+    MetadataIndex.getInstance();
   }
 
   public async ready() {
@@ -92,55 +98,50 @@ export default class DiskClient implements StorageClient {
 
     const cfg = ConfigService.getInstance();
     const storageDir = cfg.get<string>('storagePath');
-    const storageVideos = await getSortedVideos(storageDir);
-
-    // When the "review locally while relocating" feature is active, also
-    // surface videos that currently only exist in the local staging dir. Dedupe
-    // by name, preferring the storage copy (which is canonical once relocated).
     const stagingDir = getStagingDir(cfg);
-    let stagingVideos: FileInfo[] = [];
+
+    // Reconcile the in-memory metadata index with the storage dir. This is
+    // delta-only: a single readdir, reading just the files new since last time.
+    // The bulk of refreshes (after a record/clip/delete) change nothing and so
+    // cost only the readdir, instead of re-stat'ing and re-parsing every video.
+    const index = MetadataIndex.getInstance();
+    await index.reconcile(storageDir);
+    const storageVideos = index.list();
+
+    // When the "review locally while relocating" feature is active, also surface
+    // videos that currently only exist in the local staging dir. The index's
+    // write hook catches staging videos cut this session, but not ones left over
+    // from a previous session (e.g. a restart mid-relocation), so scan for those
+    // here. Dedupe by name against what's already listed so nothing appears
+    // twice, and tag the survivors as relocating.
+    let stagingVideos: RendererVideo[] = [];
 
     if (stagingDir && (await exists(stagingDir))) {
-      const onStorage = new Set(
-        storageVideos.map((v) => path.basename(v.name, '.mp4')),
+      const alreadyListed = new Set(
+        storageVideos.map((v) => path.basename(v.videoSource, '.mp4')),
       );
 
       const staged = await getSortedVideos(stagingDir);
 
-      stagingVideos = staged.filter(
-        (v) => !onStorage.has(path.basename(v.name, '.mp4')),
-      );
-    }
-
-    const videos = [...storageVideos, ...stagingVideos];
-
-    if (videos.length === 0) {
-      return [];
-    }
-
-    // Windows has a 16k file handle limit per process. Load in batches
-    // of 1000 to be safe. The real fix here would be to have a local database
-    // for managing this stuff rather than reading many thousand files here.
-    const batchSize = 1000;
-    const videoDetails: RendererVideo[] = [];
-
-    for (let i = 0; i < videos.length; i += batchSize) {
-      console.info('[DiskClient] Batch loading videos', i, 'to', i + batchSize);
-      const batch = videos.slice(i, i + batchSize);
-
-      const batchPromises = batch.map((video) =>
-        loadVideoDetailsDisk(video).catch((e) => e),
+      const stagingOnly = staged.filter(
+        (v) => !alreadyListed.has(path.basename(v.name, '.mp4')),
       );
 
-      const batchResults = await Promise.all(batchPromises);
-
-      videoDetails.push(
-        ...batchResults.filter((result) => !(result instanceof Error)),
+      const loaded = await Promise.all(
+        stagingOnly.map((v) => loadVideoDetailsDisk(v).catch((e) => e)),
       );
+
+      stagingVideos = loaded
+        .filter((r): r is RendererVideo => !(r instanceof Error))
+        .map((rv) => ({ ...rv, relocating: true }));
     }
+
+    const videoDetails = [...storageVideos, ...stagingVideos];
 
     // Tag any videos still being served from the local staging dir, so the
-    // frontend can optionally indicate they're mid-relocation to storage.
+    // frontend can optionally indicate they're mid-relocation to storage. This
+    // catches staging videos that ARE in the index (cut this session via the
+    // write hook); restart-only staging videos are already tagged above.
     if (stagingDir) {
       const resolvedStaging = path.resolve(stagingDir);
 

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -1,4 +1,6 @@
+import path from 'path';
 import ConfigService from 'config/ConfigService';
+import { getStagingDir } from 'utils/configUtils';
 import StorageClient from './StorageClient';
 import {
   delayedDeleteVideo,
@@ -11,7 +13,7 @@ import {
   openSystemExplorer,
   writeMetadataFile,
 } from 'main/util';
-import { DiskStatus, RendererVideo } from 'main/types';
+import { DiskStatus, FileInfo, RendererVideo } from 'main/types';
 import DiskSizeMonitor from './DiskSizeMonitor';
 import { ipcMain } from 'electron';
 import assert from 'assert';
@@ -88,8 +90,29 @@ export default class DiskClient implements StorageClient {
 
     console.info('[DiskClient] Getting videos from disk');
 
-    const storageDir = ConfigService.getInstance().get<string>('storagePath');
-    const videos = await getSortedVideos(storageDir);
+    const cfg = ConfigService.getInstance();
+    const storageDir = cfg.get<string>('storagePath');
+    const storageVideos = await getSortedVideos(storageDir);
+
+    // When the "review locally while relocating" feature is active, also
+    // surface videos that currently only exist in the local staging dir. Dedupe
+    // by name, preferring the storage copy (which is canonical once relocated).
+    const stagingDir = getStagingDir(cfg);
+    let stagingVideos: FileInfo[] = [];
+
+    if (stagingDir && (await exists(stagingDir))) {
+      const onStorage = new Set(
+        storageVideos.map((v) => path.basename(v.name, '.mp4')),
+      );
+
+      const staged = await getSortedVideos(stagingDir);
+
+      stagingVideos = staged.filter(
+        (v) => !onStorage.has(path.basename(v.name, '.mp4')),
+      );
+    }
+
+    const videos = [...storageVideos, ...stagingVideos];
 
     if (videos.length === 0) {
       return [];
@@ -114,6 +137,18 @@ export default class DiskClient implements StorageClient {
       videoDetails.push(
         ...batchResults.filter((result) => !(result instanceof Error)),
       );
+    }
+
+    // Tag any videos still being served from the local staging dir, so the
+    // frontend can optionally indicate they're mid-relocation to storage.
+    if (stagingDir) {
+      const resolvedStaging = path.resolve(stagingDir);
+
+      videoDetails.forEach((video) => {
+        if (path.resolve(path.dirname(video.videoSource)) === resolvedStaging) {
+          video.relocating = true;
+        }
+      });
     }
 
     // Any details marked for deletion do it now. We allow for this flag to be

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -1,23 +1,18 @@
-import { FileInfo, FileSortDirection } from '../main/types';
+import { RendererVideo } from '../main/types';
 import ConfigService from '../config/ConfigService';
-import {
-  deleteVideoDisk,
-  getMetadataForVideo,
-  getSortedVideos,
-} from '../main/util';
+import { deleteVideoDisk } from '../main/util';
 import DiskClient from './DiskClient';
-
-// Had a bug here where we used filter with an async function but that isn't
-// valid as it just returns a truthy promise. See issue 323. To get around
-// this we do some creative stuff from here:
-// https://advancedweb.hu/how-to-use-async-functions-with-array-filter-in-javascript/
-const asyncFilter = async (fileStream: FileInfo[], filter: any) => {
-  const results = await Promise.all(fileStream.map(filter));
-  return fileStream.filter((_, index) => results[index]);
-};
+import MetadataIndex from './MetadataIndex';
 
 export default class DiskSizeMonitor {
   private cfg = ConfigService.getInstance();
+
+  /**
+   * Sum the on-disk size of a list of indexed videos.
+   */
+  private static sumSizes(videos: RendererVideo[]) {
+    return videos.reduce((acc, video) => acc + (video.size || 0), 0);
+  }
 
   async run() {
     const storageDir = this.cfg.get<string>('storagePath');
@@ -29,14 +24,15 @@ export default class DiskSizeMonitor {
     }
 
     const maxStorageBytes = maxStorageGB * 1024 ** 3;
-    const usage = await this.usage();
-    const bytesToFree = usage - maxStorageBytes * 0.95; // Remain slightly under the threshold.
-    let bytesFreed = 0;
 
-    const files = await getSortedVideos(
-      storageDir,
-      FileSortDirection.OldestFirst,
-    );
+    // Read from the in-memory metadata index instead of scanning the storage
+    // dir and reading every .json. The index is kept coherent by the storage
+    // hooks (writeMetadataFile / deleteVideoDisk).
+    const index = MetadataIndex.getInstance();
+    await index.ready(storageDir);
+
+    const usage = DiskSizeMonitor.sumSizes(index.list());
+    const bytesToFree = usage - maxStorageBytes * 0.95; // Remain slightly under.
 
     console.info(
       '[DiskSizeMonitor] Running, size limit is',
@@ -44,26 +40,20 @@ export default class DiskSizeMonitor {
       'GB',
     );
 
-    const unprotectedFiles = await asyncFilter(
-      files,
-      async (file: FileInfo) => {
-        try {
-          const metadata = await getMetadataForVideo(file.name);
-          const isUnprotected = !(metadata.protected || false);
-          return isUnprotected;
-        } catch {
-          console.error(
-            '[DiskSizeMonitor] Failed to get metadata for',
-            file.name,
-          );
-          await deleteVideoDisk(file.name);
-          return false;
-        }
-      },
-    );
+    if (bytesToFree <= 0) {
+      return;
+    }
 
-    const filesForDeletion = unprotectedFiles.filter((file) => {
-      bytesFreed += file.size;
+    // Oldest first, unprotected only.
+    const candidates = index
+      .list()
+      .sort((a, b) => a.mtime - b.mtime)
+      .filter((video) => !video.isProtected);
+
+    let bytesFreed = 0;
+
+    const filesForDeletion = candidates.filter((video) => {
+      bytesFreed += video.size || 0;
       return bytesFreed < bytesToFree;
     });
 
@@ -72,8 +62,9 @@ export default class DiskSizeMonitor {
     );
 
     await Promise.all(
-      filesForDeletion.map(async (file) => {
-        await deleteVideoDisk(file.name);
+      filesForDeletion.map(async (video) => {
+        // deleteVideoDisk evicts the entry from the index via the delete hook.
+        await deleteVideoDisk(video.videoSource);
       }),
     );
 
@@ -85,12 +76,8 @@ export default class DiskSizeMonitor {
 
   public async usage() {
     const storageDir = this.cfg.get<string>('storagePath');
-    const files = await getSortedVideos(storageDir);
-
-    if (files.length < 1) {
-      return 0;
-    }
-
-    return files.map((file) => file.size).reduce((acc, num) => acc + num, 0);
+    const index = MetadataIndex.getInstance();
+    await index.ready(storageDir);
+    return DiskSizeMonitor.sumSizes(index.list());
   }
 }

--- a/src/storage/MetadataIndex.ts
+++ b/src/storage/MetadataIndex.ts
@@ -1,0 +1,232 @@
+import path from 'path';
+import { promises as fspromise } from 'fs';
+import { Metadata, RendererVideo } from '../main/types';
+import {
+  getFileInfo,
+  loadVideoDetailsDisk,
+  setStorageIndexHooks,
+} from '../main/util';
+
+/**
+ * In-memory index of disk VOD metadata, keyed by resolved video file path.
+ *
+ * Motivation: previously every refresh re-listed the storage dir, stat'd every
+ * file and read+parsed every .json sidecar (O(N) disk I/O), and this was
+ * amplified 3-5x per operation by the DiskSizeMonitor + refreshStatus +
+ * refreshVideos fan-out. On network storage each of those is a round-trip, so
+ * cost grew with library size, forever.
+ *
+ * This index is built once (reconcile) and then kept coherent incrementally via
+ * hooks on the two storage chokepoints (writeMetadataFile / deleteVideoDisk).
+ * Reconcile is delta-only: a single readdir diffs the directory against the
+ * index, and only NEW files are stat'd + read; existing files cost zero I/O
+ * (their mtime is stable and our own metadata edits update the index via the
+ * write hook). So refreshes are effectively in-memory.
+ */
+export default class MetadataIndex {
+  private static instance: MetadataIndex;
+
+  /**
+   * key: resolved absolute path of the .mp4 -> built RendererVideo.
+   */
+  private entries = new Map<string, RendererVideo>();
+
+  /**
+   * The storage dir the index was last reconciled against. Used to detect a
+   * storage-path change (which requires a fresh reconcile).
+   */
+  private reconciledDir: string | null = null;
+
+  /**
+   * In-flight reconcile, if any. Used to coalesce concurrent reconciles (e.g.
+   * refreshStatus + refreshVideos firing together at startup) so we don't read
+   * every metadata file twice.
+   */
+  private inFlight: Promise<void> | null = null;
+
+  public static getInstance(): MetadataIndex {
+    if (!this.instance) {
+      this.instance = new MetadataIndex();
+    }
+
+    return this.instance;
+  }
+
+  private constructor() {
+    // Keep the index coherent automatically: any metadata write or video
+    // deletion anywhere in the app updates the index via these hooks. Done in
+    // the constructor so simply touching getInstance() once at startup wires it
+    // up before any write happens.
+    setStorageIndexHooks(
+      (videoPath: string, metadata: Metadata) =>
+        this.onMetadataWritten(videoPath, metadata),
+      (videoPath: string) => this.remove(videoPath),
+    );
+  }
+
+  private static key(videoPath: string) {
+    return path.resolve(videoPath);
+  }
+
+  /**
+   * Build (or update) the index for the given storage dir. Delta-only: a single
+   * readdir, evict entries whose file vanished, and stat+read only files not
+   * already cached. Cheap enough to call on every refresh. Concurrent calls are
+   * coalesced onto a single in-flight reconcile.
+   */
+  public async reconcile(storageDir: string): Promise<void> {
+    if (this.inFlight) {
+      await this.inFlight;
+      return;
+    }
+
+    this.inFlight = this.doReconcile(storageDir);
+
+    try {
+      await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async doReconcile(storageDir: string): Promise<void> {
+    let names: string[];
+
+    try {
+      names = (await fspromise.readdir(storageDir)).filter((f) =>
+        f.match(/.*\.mp4$/),
+      );
+    } catch (error) {
+      console.warn(
+        '[MetadataIndex] Failed to read storage dir, keeping cache',
+        storageDir,
+        String(error),
+      );
+      return;
+    }
+
+    const resolvedDir = path.resolve(storageDir);
+    const presentKeys = new Set(
+      names.map((n) => MetadataIndex.key(path.join(storageDir, n))),
+    );
+
+    // Evict entries (belonging to this dir) whose file has disappeared.
+    [...this.entries.keys()].forEach((k) => {
+      const entry = this.entries.get(k);
+      if (!entry) return;
+
+      const entryDir = path.resolve(path.dirname(entry.videoSource));
+
+      if (entryDir === resolvedDir && !presentKeys.has(k)) {
+        this.entries.delete(k);
+      }
+    });
+
+    // Load only files not already cached. Batch to avoid file-handle limits
+    // (Windows has a ~16k handle limit per process).
+    const newPaths = names
+      .map((n) => path.join(storageDir, n))
+      .filter((p) => !this.entries.has(MetadataIndex.key(p)));
+
+    const batchSize = 1000;
+
+    for (let i = 0; i < newPaths.length; i += batchSize) {
+      const batch = newPaths.slice(i, i + batchSize);
+
+      const infos = await Promise.all(
+        batch.map((p) => getFileInfo(p).catch((e) => e)),
+      );
+
+      const built = await Promise.all(
+        infos.map((info) =>
+          info instanceof Error
+            ? Promise.resolve(info)
+            : loadVideoDetailsDisk(info).catch((e) => e),
+        ),
+      );
+
+      built.forEach((rv, idx) => {
+        if (rv instanceof Error) {
+          return;
+        }
+
+        const info = infos[idx];
+
+        if (!(info instanceof Error)) {
+          // Prefer the real on-disk size over metadata.size (which may be
+          // absent on older videos) so disk-usage accounting stays accurate.
+          rv.size = info.size;
+        }
+
+        this.entries.set(MetadataIndex.key(rv.videoSource), rv);
+      });
+    }
+
+    this.reconciledDir = resolvedDir;
+  }
+
+  /**
+   * Ensure the index has been built for this dir at least once.
+   */
+  public async ready(storageDir: string): Promise<void> {
+    if (this.reconciledDir === path.resolve(storageDir)) {
+      return;
+    }
+
+    await this.reconcile(storageDir);
+  }
+
+  /**
+   * Return all indexed videos, newest first. Pure in-memory, no disk I/O.
+   */
+  public list(): RendererVideo[] {
+    return [...this.entries.values()].sort((a, b) => b.mtime - a.mtime);
+  }
+
+  /**
+   * Update/insert an entry after its metadata file was written. Reuses the
+   * cached mtime for a known file; stats the file once for a newly added video.
+   */
+  private async onMetadataWritten(videoPath: string, metadata: Metadata) {
+    const key = MetadataIndex.key(videoPath);
+    const existing = this.entries.get(key);
+
+    let mtime = existing?.mtime;
+    let size = existing?.size ?? metadata.size;
+
+    if (mtime === undefined) {
+      // New file: stat it once for mtime and real size. (Existing files reuse
+      // their cached mtime/size; tag/protect/delete-flag don't change the mp4.)
+      try {
+        const info = await getFileInfo(videoPath);
+        mtime = info.mtime;
+        size = info.size;
+      } catch {
+        // The .mp4 should exist (metadata is written after it). If not, sort it
+        // newest for now; a later reconcile will correct it.
+        mtime = Date.now();
+      }
+    }
+
+    const videoName = path.basename(videoPath, '.mp4');
+
+    this.entries.set(key, {
+      ...metadata,
+      videoName,
+      mtime,
+      size,
+      videoSource: videoPath,
+      isProtected: Boolean(metadata.protected),
+      cloud: false,
+      multiPov: [],
+      uniqueId: `${videoName}-disk`,
+    });
+  }
+
+  /**
+   * Evict an entry after its video was deleted.
+   */
+  public remove(videoPath: string) {
+    this.entries.delete(MetadataIndex.key(videoPath));
+  }
+}

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -207,6 +207,36 @@ const getBaseConfig = (cfg: ConfigService): BaseConfig => {
   };
 };
 
+/**
+ * Name of the subdirectory (within the local buffer dir) used to stage freshly
+ * cut MP4s so they can be reviewed locally before being relocated to the NAS.
+ */
+const STAGING_DIR_NAME = '.staging';
+
+/**
+ * Returns the local staging directory used by the "review locally while
+ * relocating to storage" feature, or null when it doesn't apply.
+ *
+ * Staging only makes sense when a separate (fast, local) buffer path is
+ * configured distinct from the storage path. When there is no separate buffer
+ * (buffer lives under storagePath/.temp) there's no faster-than-storage disk to
+ * stage on, so we return null and callers fall back to current behaviour
+ * (cutting straight to storagePath).
+ */
+const getStagingDir = (cfg: ConfigService): string | null => {
+  if (!cfg.get<boolean>('separateBufferPath')) {
+    return null;
+  }
+
+  const bufferPath = cfg.getPath('bufferStoragePath');
+
+  if (!bufferPath) {
+    return null;
+  }
+
+  return path.join(bufferPath, STAGING_DIR_NAME);
+};
+
 const getObsVideoConfig = (cfg: ConfigService): ObsVideoConfig => {
   return {
     obsCaptureMode: cfg.get<string>('obsCaptureMode'),
@@ -485,6 +515,7 @@ export {
   allowRecordCategory,
   shouldUpload,
   getBaseConfig,
+  getStagingDir,
   getObsVideoConfig,
   getObsAudioConfig,
   getOverlayConfig,


### PR DESCRIPTION
I apologize in advance for doing this as a single PR, but I've been working with, testing on, and using this integration branch locally for a few weeks now while raiding and wanted to share.

I'll let the code mostly speak for itself but here's an at-a-glance look:

## What this PR changes

| Change-set | Before (upstream) | After (this PR) |
|---|---|---|
| **Time-keyed VOD annotations** | An Excalidraw drawing overlay existed, but drawings were **ephemeral** and never saved, and lost on close or POV switch. One whole-VOD canvas, no time dimension, and no way to clear it. | Drawings **persist per video file** as a time-indexed **keyframe** record: each edit snapshots at the playhead, and on playback a keyframe **flashes near its timestamp** (and holds while paused). Adds scrubber keyframe markers, an adjustable display-duration slider (persisted in config), a clear-all control, and auto-removal of a keyframe once its contents are erased. Disabled in multi-POV grid mode so markup stays tied to a single viewpoint's file. |
| **Review while relocating to storage** | A freshly cut recording was moved from the local buffer to permanent storage (e.g. a NAS) **before it became reviewable**. You had to wait for the transfer to finish to watch the latest VOD. | The VOD is **reviewable immediately** from a local staging copy while it is copied to storage in the background; playback **cuts over seamlessly** to the permanent copy when the move completes (no stall on seek). A progress bar under the status indicator shows the move, and staging copies are cleaned up mid-session. |
| **In-memory metadata index** | Every video-list refresh **re-scanned the storage dir and re-parsed every `.json` sidecar** (O(N) disk I/O), amplified per operation and costly on network storage where each file is a round-trip, so cost grew with library size on every refresh. | A metadata index is **built once and kept coherent via write/delete hooks**. Refreshes are **delta-only** (a single `readdir`, parsing only newly-seen files) and effectively in-memory; annotation saves rebuild from the index without re-scanning storage. |

## Anecdotes

I've been using this branch against Retail WoW captures for over a month now. The main values adds are as follows:

- Users with a fast buffer and slow storage location and/or extremely large capture sizes (various quality settings) were generally unable to review VODs until they were moved. This is seamless, let's the move happen cleanly in the background, and generally makes the experience that much smoother when you _really_ need to start reviewing a wipe as soon as its ended. 

- Annotations are sweet, but they were mostly a real-time tool that had minimal value outside of a "hey watch my stream real quick, here's a laser pointer". Now they'll persist on the VOD, you can replay and jump around and it'll stick with it.

I added a few controls to support this, as well as the markers on the scrubber. See image:


<img width="1303" height="195" alt="annotations-saved-timeline-controls" src="https://github.com/user-attachments/assets/6916b427-d50f-4e81-ac79-bde962239cd6" />

- The bugfix was mainly a poor scaling on the VOD directory reads. It was a freebie to fix and the cache is durable, lightweight and better supports responsiveness of the app as the VOD library grows.


-----

I'm open to any feedback here. I definitely leaned on Claude to try and keep this as clean as I could especially since I **don't personally use the Pro features**.

If you hate the big-ass PR, I'll totally understand.

Thanks for the awesome app, hopefully my contribution here is helpful!