### PR TITLE
Fix repeated playback toggles when holding spacebar

### DIFF
--- a/src/renderer/VideoPlayer.tsx
+++ b/src/renderer/VideoPlayer.tsx
@@ -1264,14 +1264,19 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, IProps>((props, ref) => {
    * such events, so instead we do this.
    */
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (!player1.current) {
+    if (e.key === 'k' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (player1.current && !e.repeat) {
+        togglePlaying();
+      }
+
       return;
     }
 
-    if (e.key === 'k' || e.key === ' ') {
-      togglePlaying();
-      e.preventDefault();
-      e.stopPropagation();
+    if (!player1.current) {
+      return;
     }
 
     if (e.key === 'j' || e.key === 'ArrowLeft') {

--- a/src/renderer/components/Tables/VideoSelectionTable.tsx
+++ b/src/renderer/components/Tables/VideoSelectionTable.tsx
@@ -1,12 +1,7 @@
 import { AppState, RendererVideo } from 'main/types';
 
 import { Cell, flexRender, Header, Row, Table } from '@tanstack/react-table';
-import React, {
-  Fragment,
-  RefObject,
-  useCallback,
-  useEffect,
-} from 'react';
+import React, { Fragment, RefObject, useCallback, useEffect } from 'react';
 import {
   ArrowDown,
   ArrowUp,
@@ -122,10 +117,13 @@ const VideoSelectionTable = (props: IProps) => {
    */
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      const sortedRows = table.getSortedRowModel().rows;
-      const selectedRows = table.getSelectedRowModel().rows;
+      if (event.repeat) {
+        return;
+      }
 
       if (event.key === 'a' && event.ctrlKey) {
+        const sortedRows = table.getSortedRowModel().rows;
+
         sortedRows.forEach((row) => {
           if (!row.getIsSelected()) {
             row.getToggleSelectedHandler()(event);
@@ -137,10 +135,10 @@ const VideoSelectionTable = (props: IProps) => {
         return;
       }
 
-      if (
-        (event.key === 'ArrowDown' || event.key === 'ArrowUp') &&
-        !event.repeat
-      ) {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        const sortedRows = table.getSortedRowModel().rows;
+        const selectedRows = table.getSelectedRowModel().rows;
+
         if (selectedRows.length === 0) return;
 
         const currentRow =


### PR DESCRIPTION
## Summary

This fixes a playback hotkey issue where holding Space while viewing a video could repeatedly toggle play/pause and leave the user stuck in a playback loop.

The fix keeps the scope intentionally small:

- Playback hotkeys still call `preventDefault()` / `stopPropagation()` so the browser/player does not handle Space separately.
- Repeated `keydown` events for Space/K are ignored, so holding the key only toggles playback once.
- The video selection table now returns early for repeated or unrelated key events before building sorted/selected row models.

## Root Cause

The video player handled playback hotkeys from a global `keydown` listener. Browsers keep firing repeated `keydown` events while a key is held, and the old handler treated each repeat as a fresh playback toggle.

There was also a separate global key handler in the video selection table that did table row work before confirming the key was relevant. While holding Space, those repeated events could make the UI feel unresponsive even though Space is not a table navigation key.

## Notes

This PR does not attempt to change behavior for extremely rapid manual Space/K tapping. That case appears to be separate from the reported hold-to-repeat issue and is left out to keep this fix low-risk.

Fixes #856

## Testing

- `npx.cmd eslint src/renderer/VideoPlayer.tsx src/renderer/components/Tables/VideoSelectionTable.tsx`
- `git diff --check origin/main..HEAD`