### PR TITLE
[codex] Fix cross-source log activity ownership

### DIFF
--- a/src/main/Manager.ts
+++ b/src/main/Manager.ts
@@ -44,7 +44,7 @@ import {
   runRetailRecordingTest,
 } from '../utils/testButtonUtils';
 import VideoProcessQueue from './VideoProcessQueue';
-import LogHandler from 'parsing/LogHandler';
+import LogHandler, { LogHandlerSource } from 'parsing/LogHandler';
 import { PTTKeyPressEvent } from 'types/KeyTypesUIOHook';
 import { send } from './main';
 import DiskClient from 'storage/DiskClient';
@@ -504,7 +504,7 @@ export default class Manager {
     }
 
     if (config.recordClassicPtr) {
-      this.classicPtrLogHandler = new ClassicLogHandler(config.classicPtrLogPath);
+      this.classicPtrLogHandler = new ClassicLogHandler(config.classicPtrLogPath, LogHandlerSource.ClassicPtr);
     }
 
     if (config.recordEra) {
@@ -512,7 +512,7 @@ export default class Manager {
     }
 
     if (config.recordRetailPtr) {
-      this.retailPtrLogHandler = new RetailLogHandler(config.retailPtrLogPath);
+      this.retailPtrLogHandler = new RetailLogHandler(config.retailPtrLogPath, LogHandlerSource.RetailPtr);
       this.retailPtrLogHandler.setIsPtr();
     }
   }

--- a/src/parsing/ClassicLogHandler.ts
+++ b/src/parsing/ClassicLogHandler.ts
@@ -5,7 +5,7 @@ import {
   classicUniqueSpecSpells,
   mopChallengeModes,
 } from '../main/constants';
-import LogHandler from './LogHandler';
+import LogHandler, { LogHandlerSource } from './LogHandler';
 import { Flavour } from '../main/types';
 import ArenaMatch from '../activitys/ArenaMatch';
 import { isUnitFriendly, isUnitPlayer, isUnitSelf } from './logutils';
@@ -20,8 +20,8 @@ import ConfigService from 'config/ConfigService';
  * Classic log handler class.
  */
 export default class ClassicLogHandler extends LogHandler {
-  constructor(logPath: string) {
-    super(logPath, 2);
+  constructor(logPath: string, source = LogHandlerSource.Classic) {
+    super(logPath, 2, source);
 
     /* eslint-disable prettier/prettier */
     this.combatLogWatcher
@@ -50,7 +50,11 @@ export default class ClassicLogHandler extends LogHandler {
   }
 
   private handleSpellAuraAppliedLine(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('spell aura')
+    ) {
       // Deliberately don't log anything here as we can hit this a lot
       return;
     }
@@ -97,6 +101,10 @@ export default class ClassicLogHandler extends LogHandler {
       return;
     }
 
+    if (this.shouldIgnoreActiveActivity('zone change')) {
+      return;
+    }
+
     const zoneID = parseInt(line.arg(1), 10);
 
     const isZoneArena = Object.prototype.hasOwnProperty.call(
@@ -138,7 +146,11 @@ export default class ClassicLogHandler extends LogHandler {
   }
 
   protected handleUnitDiedLine(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('unit death')
+    ) {
       // Deliberately don't log anything here as we can hit this a lot
       return;
     }
@@ -160,7 +172,11 @@ export default class ClassicLogHandler extends LogHandler {
   }
 
   private handleSpellCastSuccess(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('spell cast')
+    ) {
       // Deliberately don't log anything here as we can hit this a lot
       return;
     }
@@ -217,7 +233,7 @@ export default class ClassicLogHandler extends LogHandler {
       Flavour.Classic,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private static calculateArenaResult(arenaMatch: ArenaMatch) {
@@ -243,10 +259,16 @@ export default class ClassicLogHandler extends LogHandler {
     }
 
     console.debug('[ClassicLogHandler] Stopping arena at date:', endDate);
+
+    if (!this.ownsActiveActivity()) {
+      await this.endActivityForSource('arena end');
+      return;
+    }
+
     const arenaMatch = LogHandler.activity as ArenaMatch;
     const result = await ClassicLogHandler.calculateArenaResult(arenaMatch);
     arenaMatch.endArena(endDate, result);
-    await LogHandler.endActivity();
+    await this.endActivityForSource('arena end');
   }
 
   protected processClassicCombatant(
@@ -258,6 +280,10 @@ export default class ClassicLogHandler extends LogHandler {
     destFlags: number,
   ) {
     if (!LogHandler.activity) {
+      return undefined;
+    }
+
+    if (this.shouldIgnoreActiveActivity('classic combatant processing')) {
       return undefined;
     }
 
@@ -327,6 +353,10 @@ export default class ClassicLogHandler extends LogHandler {
       return;
     }
 
+    if (this.shouldIgnoreActiveActivity('arena death processing')) {
+      return;
+    }
+
     let totalFriends = 0;
     let totalEnemies = 0;
 
@@ -381,7 +411,7 @@ export default class ClassicLogHandler extends LogHandler {
       Flavour.Classic,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async battlegroundEnd(line: LogLine) {
@@ -392,9 +422,14 @@ export default class ClassicLogHandler extends LogHandler {
       return;
     }
 
+    if (!this.ownsActiveActivity()) {
+      await this.endActivityForSource('battleground end');
+      return;
+    }
+
     const endTime = line.date();
     LogHandler.activity.end(endTime, false);
-    await LogHandler.endActivity();
+    await this.endActivityForSource('battleground end');
   }
 
   private handleCombatantInfoLine(line: LogLine) {
@@ -409,6 +444,10 @@ export default class ClassicLogHandler extends LogHandler {
       console.warn(
         '[ClassicLogHandler] No activity in progress, ignoring COMBATANT_INFO',
       );
+      return;
+    }
+
+    if (this.shouldIgnoreActiveActivity('combatant info')) {
       return;
     }
 
@@ -441,6 +480,10 @@ export default class ClassicLogHandler extends LogHandler {
 
     if (this.isManual()) {
       console.info('[ClassicLogHandler] Ignoring line as in manual recording');
+      return;
+    }
+
+    if (this.shouldIgnoreActiveActivity('challenge mode start')) {
       return;
     }
 
@@ -489,7 +532,7 @@ export default class ClassicLogHandler extends LogHandler {
       Flavour.Classic,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async handleChallengeModeEndLine(line: LogLine) {
@@ -510,10 +553,15 @@ export default class ClassicLogHandler extends LogHandler {
       return;
     }
 
+    if (!this.ownsActiveActivity()) {
+      await this.endActivityForSource('challenge mode end');
+      return;
+    }
+
     const challengeModeActivity = LogHandler.activity as ChallengeModeDungeon;
     const endDate = line.date();
 
     challengeModeActivity.endChallengeMode(endDate, 0, true);
-    await LogHandler.endActivity();
+    await this.endActivityForSource('challenge mode end');
   }
 }

--- a/src/parsing/EraLogHandler.ts
+++ b/src/parsing/EraLogHandler.ts
@@ -1,4 +1,4 @@
-import LogHandler from './LogHandler';
+import LogHandler, { LogHandlerSource } from './LogHandler';
 import { Flavour } from '../main/types';
 import { isUnitPlayer } from './logutils';
 import LogLine from './LogLine';
@@ -10,7 +10,7 @@ import { classicUniqueSpecSpells } from '../main/constants';
  */
 export default class EraLogHandler extends LogHandler {
   constructor(logPath: string) {
-    super(logPath, 2);
+    super(logPath, 2, LogHandlerSource.Era);
 
     /* eslint-disable prettier/prettier */
     this.combatLogWatcher
@@ -49,6 +49,10 @@ export default class EraLogHandler extends LogHandler {
       return;
     }
 
+    if (this.shouldIgnoreActiveActivity('combatant info')) {
+      return;
+    }
+
     const GUID = line.arg(1);
     const teamID = parseInt(line.arg(2), 10);
 
@@ -71,7 +75,11 @@ export default class EraLogHandler extends LogHandler {
   }
 
   private handleSpellAuraAppliedLine(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('spell aura')
+    ) {
       // Deliberately don't log anything here as we hit this a lot
       return;
     }
@@ -83,7 +91,11 @@ export default class EraLogHandler extends LogHandler {
   }
 
   private handleSpellCastSuccess(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('spell cast')
+    ) {
       // Deliberately don't log anything here as we hit this a lot
       return;
     }
@@ -121,6 +133,10 @@ export default class EraLogHandler extends LogHandler {
       return undefined;
     }
 
+    if (this.shouldIgnoreActiveActivity('era combatant processing')) {
+      return undefined;
+    }
+
     const combatant = super.processCombatant(
       srcGUID,
       srcNameRealm,
@@ -145,6 +161,10 @@ export default class EraLogHandler extends LogHandler {
 
     if (!LogHandler.activity) {
       console.info('[EraLogHandler] Ignoring line as no activity in progress');
+      return;
+    }
+
+    if (this.shouldIgnoreActiveActivity('unit death')) {
       return;
     }
 

--- a/src/parsing/LogHandler.ts
+++ b/src/parsing/LogHandler.ts
@@ -42,6 +42,14 @@ import { ESupportedEncoders } from 'main/obsEnums';
  * typically have up to 4 child classes, we don't want multiple concurrent
  * activities.
  */
+export enum LogHandlerSource {
+  Retail = 'retail',
+  RetailPtr = 'retailPtr',
+  Classic = 'classic',
+  ClassicPtr = 'classicPtr',
+  Era = 'era',
+}
+
 export default abstract class LogHandler {
   public static activity: Activity | undefined;
 
@@ -50,6 +58,11 @@ export default abstract class LogHandler {
   public combatLogWatcher: CombatLogWatcher;
 
   protected player: Combatant | undefined;
+
+  protected readonly source: LogHandlerSource;
+
+  // The active activity is shared, so remember which watcher is allowed to mutate it.
+  private static activitySource: LogHandlerSource | undefined;
 
   private static stateChangeCallback: () => void;
 
@@ -60,7 +73,8 @@ export default abstract class LogHandler {
    */
   protected logProcessQueue = new AsyncQueue(Number.MAX_SAFE_INTEGER);
 
-  constructor(logPath: string, dataTimeout: number) {
+  constructor(logPath: string, dataTimeout: number, source: LogHandlerSource) {
+    this.source = source;
     this.combatLogWatcher = new CombatLogWatcher(logPath, dataTimeout);
     this.combatLogWatcher.watch();
     const lpq = this.logProcessQueue;
@@ -71,7 +85,7 @@ export default abstract class LogHandler {
 
     // For ease of testing force stop.
     this.combatLogWatcher.on('WARCRAFT_RECORDER_FORCE_STOP', () => {
-      lpq.add(async () => LogHandler.forceEndActivity());
+      lpq.add(async () => LogHandler.forceEndActivity(0, this.source));
     });
   }
 
@@ -124,7 +138,7 @@ export default abstract class LogHandler {
       flavour,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   protected async handleEncounterEndLine(line: LogLine) {
@@ -137,6 +151,16 @@ export default abstract class LogHandler {
 
     if (!LogHandler.activity) {
       console.info('[LogHandler] Encounter stop with no active encounter');
+      return;
+    }
+
+    if (!this.ownsActiveActivity()) {
+      console.info(
+        '[LogHandler] Ignoring encounter end from source',
+        this.source,
+        'for active source',
+        LogHandler.activitySource,
+      );
       return;
     }
 
@@ -163,6 +187,10 @@ export default abstract class LogHandler {
 
   protected handleUnitDiedLine(line: LogLine): void {
     if (!LogHandler.activity) {
+      return;
+    }
+
+    if (this.shouldIgnoreActiveActivity('unit death')) {
       return;
     }
 
@@ -208,12 +236,33 @@ export default abstract class LogHandler {
     LogHandler.activity.addDeath(playerDeath);
   }
 
-  protected static async startActivity(activity: Activity) {
+  protected async startActivity(activity: Activity) {
+    await LogHandler.startActivity(activity, this.source);
+  }
+
+  protected static async startActivity(
+    activity: Activity,
+    source?: LogHandlerSource,
+  ) {
     const { category } = activity;
     const allowed = allowRecordCategory(ConfigService.getInstance(), category);
 
     if (!allowed) {
       console.info('[LogHandler] Not configured to record', category);
+      return;
+    }
+
+    if (
+      LogHandler.activity &&
+      !LogHandler.activeActivityMatchesSource(source)
+    ) {
+      // Another log source may emit starts while a recording is active.
+      console.info(
+        '[LogHandler] Ignoring activity start from source',
+        source,
+        'for active source',
+        LogHandler.activitySource,
+      );
       return;
     }
 
@@ -230,11 +279,13 @@ export default abstract class LogHandler {
 
     try {
       LogHandler.activity = activity;
+      LogHandler.activitySource = source;
       await Recorder.getInstance().startRecording(offset);
       LogHandler.stateChangeCallback();
     } catch (error) {
       console.error('[LogHandler] Error starting activity', String(error));
       LogHandler.activity = undefined;
+      LogHandler.activitySource = undefined;
     }
   }
 
@@ -258,6 +309,7 @@ export default abstract class LogHandler {
     const lastActivity = LogHandler.activity;
     LogHandler.overrunning = true;
     LogHandler.activity = undefined;
+    LogHandler.activitySource = undefined;
 
     const { overrun } = lastActivity;
 
@@ -365,13 +417,69 @@ export default abstract class LogHandler {
     );
 
     if (LogHandler.activity) {
-      await LogHandler.forceEndActivity(-ms / 1000);
+      await LogHandler.forceEndActivity(-ms / 1000, this.source);
     }
   }
 
-  public static async forceEndActivity(timedelta = 0) {
+  protected ownsActiveActivity() {
+    return LogHandler.activeActivityMatchesSource(this.source);
+  }
+
+  // Use before parser events mutate metadata on the shared active activity.
+  protected shouldIgnoreActiveActivity(reason: string) {
+    if (!LogHandler.activity || this.ownsActiveActivity()) {
+      return false;
+    }
+
+    console.info(
+      `[LogHandler] Ignoring ${reason} from source`,
+      this.source,
+      'for active source',
+      LogHandler.activitySource,
+    );
+    return true;
+  }
+
+  protected async endActivityForSource(reason: string) {
+    if (!this.ownsActiveActivity()) {
+      console.info(
+        `[LogHandler] Ignoring ${reason} from source`,
+        this.source,
+        'for active source',
+        LogHandler.activitySource,
+      );
+      return;
+    }
+
+    await LogHandler.endActivity();
+  }
+
+  private static activeActivityMatchesSource(source?: LogHandlerSource) {
+    if (source === undefined) {
+      // Manual/global controls intentionally operate across all sources.
+      return true;
+    }
+
+    return LogHandler.activitySource === source;
+  }
+
+  public static async forceEndActivity(
+    timedelta = 0,
+    source?: LogHandlerSource,
+  ) {
     if (!LogHandler.activity) {
       console.error('[LogHandler] forceEndActivity called but no activity');
+      return;
+    }
+
+    if (!LogHandler.activeActivityMatchesSource(source)) {
+      // Timeouts and force-stops are per watcher, not global.
+      console.info(
+        '[LogHandler] Ignoring force end from source',
+        source,
+        'for active source',
+        LogHandler.activitySource,
+      );
       return;
     }
 
@@ -382,12 +490,12 @@ export default abstract class LogHandler {
 
     LogHandler.activity.end(endDate, false);
     await LogHandler.endActivity();
-    LogHandler.activity = undefined;
   }
 
   public static dropActivity() {
     LogHandler.overrunning = false;
     LogHandler.activity = undefined;
+    LogHandler.activitySource = undefined;
   }
 
   protected async zoneChangeStop(line: LogLine) {
@@ -397,13 +505,23 @@ export default abstract class LogHandler {
       return;
     }
 
+    if (!this.ownsActiveActivity()) {
+      console.info(
+        '[LogHandler] Ignoring zone change stop from source',
+        this.source,
+        'for active source',
+        LogHandler.activitySource,
+      );
+      return;
+    }
+
     const endDate = line.date();
     LogHandler.activity.end(endDate, false);
     await LogHandler.endActivity();
   }
 
   protected isArena() {
-    if (!LogHandler.activity) {
+    if (!LogHandler.activity || !this.ownsActiveActivity()) {
       return false;
     }
 
@@ -419,7 +537,7 @@ export default abstract class LogHandler {
   }
 
   protected isBattleground() {
-    if (!LogHandler.activity) {
+    if (!LogHandler.activity || !this.ownsActiveActivity()) {
       return false;
     }
 
@@ -428,7 +546,7 @@ export default abstract class LogHandler {
   }
 
   protected isMythicPlus() {
-    if (!LogHandler.activity) {
+    if (!LogHandler.activity || !this.ownsActiveActivity()) {
       return false;
     }
 
@@ -442,7 +560,7 @@ export default abstract class LogHandler {
   }
 
   protected isRaid() {
-    if (!LogHandler.activity) return false;
+    if (!LogHandler.activity || !this.ownsActiveActivity()) return false;
     return LogHandler.activity.category === VideoCategory.Raids;
   }
 
@@ -455,6 +573,10 @@ export default abstract class LogHandler {
     let combatant: Combatant | undefined;
 
     if (!LogHandler.activity) {
+      return combatant;
+    }
+
+    if (this.shouldIgnoreActiveActivity('combatant processing')) {
       return combatant;
     }
 
@@ -502,6 +624,10 @@ export default abstract class LogHandler {
   }
 
   protected handleSpellDamage(line: LogLine) {
+    if (this.shouldIgnoreActiveActivity('spell damage')) {
+      return;
+    }
+
     if (!this.isRaid()) {
       return;
     }

--- a/src/parsing/RetailLogHandler.ts
+++ b/src/parsing/RetailLogHandler.ts
@@ -11,7 +11,7 @@ import {
 } from '../main/constants';
 
 import ArenaMatch from '../activitys/ArenaMatch';
-import LogHandler from './LogHandler';
+import LogHandler, { LogHandlerSource } from './LogHandler';
 import Battleground from '../activitys/Battleground';
 import ChallengeModeDungeon from '../activitys/ChallengeModeDungeon';
 
@@ -34,8 +34,8 @@ import RaidEncounter from 'activitys/RaidEncounter';
 export default class RetailLogHandler extends LogHandler {
   private isPtr = false;
 
-  constructor(logPath: string) {
-    super(logPath, 10);
+  constructor(logPath: string, source = LogHandlerSource.Retail) {
+    super(logPath, 10, source);
 
     /* eslint-disable prettier/prettier */
     this.combatLogWatcher
@@ -74,7 +74,7 @@ export default class RetailLogHandler extends LogHandler {
       // Important we don't end an activity if we're in a Solo Shuffle,
       // we use the ARENA_MATCH_START events to keep track of the rounds.
       console.warn('[RetailLogHandler] Active activity on ARENA_START');
-      await LogHandler.forceEndActivity();
+      await LogHandler.forceEndActivity(0, this.source);
     }
 
     const startTime = line.date();
@@ -102,10 +102,19 @@ export default class RetailLogHandler extends LogHandler {
       return;
     }
 
+    if (LogHandler.activity && !this.ownsActiveActivity()) {
+      console.info(
+        '[RetailLogHandler] Ignoring arena start from source',
+        this.source,
+        'for active source owned by another handler',
+      );
+      return;
+    }
+
     if (!LogHandler.activity && category === VideoCategory.SoloShuffle) {
       console.info('[RetailLogHandler] Fresh Solo Shuffle game starting');
       const activity = new SoloShuffle(startTime, zoneID);
-      await LogHandler.startActivity(activity);
+      await this.startActivity(activity);
     } else if (LogHandler.activity && category === VideoCategory.SoloShuffle) {
       console.info(
         '[RetailLogHandler] New round of existing Solo Shuffle starting',
@@ -122,7 +131,7 @@ export default class RetailLogHandler extends LogHandler {
         Flavour.Retail,
       );
 
-      await LogHandler.startActivity(activity);
+      await this.startActivity(activity);
     }
   }
 
@@ -139,16 +148,21 @@ export default class RetailLogHandler extends LogHandler {
       return;
     }
 
+    if (!this.ownsActiveActivity()) {
+      await this.endActivityForSource('arena end');
+      return;
+    }
+
     if (LogHandler.activity.category === VideoCategory.SoloShuffle) {
       const soloShuffle = LogHandler.activity as SoloShuffle;
       soloShuffle.endGame(line.date());
-      await LogHandler.endActivity();
+      await this.endActivityForSource('arena end');
     } else {
       const arenaMatch = LogHandler.activity as ArenaMatch;
       const endTime = line.date();
       const winningTeamID = parseInt(line.arg(1), 10);
       arenaMatch.endArena(endTime, winningTeamID);
-      await LogHandler.endActivity();
+      await this.endActivityForSource('arena end');
     }
   }
 
@@ -160,6 +174,10 @@ export default class RetailLogHandler extends LogHandler {
 
     if (this.isManual()) {
       console.info('[RetailLogHandler] Ignoring line as in manual recording');
+      return;
+    }
+
+    if (this.shouldIgnoreActiveActivity('challenge mode start')) {
       return;
     }
 
@@ -223,7 +241,7 @@ export default class RetailLogHandler extends LogHandler {
     );
 
     activity.addTimelineSegment(initialSegment);
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async handleChallengeModeEndLine(line: LogLine) {
@@ -238,6 +256,11 @@ export default class RetailLogHandler extends LogHandler {
       console.error(
         '[RetailLogHandler] Challenge mode stop with no active ChallengeModeDungeon',
       );
+      return;
+    }
+
+    if (!this.ownsActiveActivity()) {
+      await this.endActivityForSource('challenge mode end');
       return;
     }
 
@@ -257,7 +280,7 @@ export default class RetailLogHandler extends LogHandler {
     }
 
     challengeModeActivity.endChallengeMode(endDate, CMDuration, result);
-    await LogHandler.endActivity();
+    await this.endActivityForSource('challenge mode end');
   }
 
   protected async handleEncounterStartLine(line: LogLine) {
@@ -265,6 +288,10 @@ export default class RetailLogHandler extends LogHandler {
 
     if (this.isManual()) {
       console.info('[RetailLogHandler] Ignoring line as in manual recording');
+      return;
+    }
+
+    if (this.shouldIgnoreActiveActivity('encounter start')) {
       return;
     }
 
@@ -289,7 +316,7 @@ export default class RetailLogHandler extends LogHandler {
       // if you abandon a key mid-pull and quickly start a raid boss
       // before WCR has realized the M+ is over.
       console.info('[RetailLogHandler] Active M+ but not a dungeon encounter');
-      await LogHandler.forceEndActivity();
+      await LogHandler.forceEndActivity(0, this.source);
     }
 
     if (!LogHandler.activity) {
@@ -372,6 +399,10 @@ export default class RetailLogHandler extends LogHandler {
       return;
     }
 
+    if (this.shouldIgnoreActiveActivity('encounter end')) {
+      return;
+    }
+
     const { category } = LogHandler.activity;
     const isChallengeMode = category === VideoCategory.MythicPlus;
 
@@ -414,6 +445,10 @@ export default class RetailLogHandler extends LogHandler {
       return;
     }
 
+    if (this.shouldIgnoreActiveActivity('zone change')) {
+      return;
+    }
+
     const zoneID = parseInt(line.arg(1), 10);
 
     const isZoneBG = Object.prototype.hasOwnProperty.call(
@@ -447,7 +482,7 @@ export default class RetailLogHandler extends LogHandler {
           '[RetailLogHandler] Zoned into BG but in a different activity',
         );
 
-        await LogHandler.forceEndActivity();
+        await LogHandler.forceEndActivity(0, this.source);
         await this.battlegroundStart(line);
       } else {
         console.info(
@@ -478,6 +513,10 @@ export default class RetailLogHandler extends LogHandler {
       return;
     }
 
+    if (this.shouldIgnoreActiveActivity('combatant info')) {
+      return;
+    }
+
     const GUID = line.arg(1);
 
     // In Mythic+ we see COMBANTANT_INFO events for each encounter.
@@ -503,7 +542,11 @@ export default class RetailLogHandler extends LogHandler {
   }
 
   private handleSpellAuraAppliedLine(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('spell aura')
+    ) {
       // Deliberately don't log anything here as we can hit this a lot
       return;
     }
@@ -550,7 +593,11 @@ export default class RetailLogHandler extends LogHandler {
   }
 
   private handleSpellCastSuccess(line: LogLine) {
-    if (!LogHandler.activity || this.isManual()) {
+    if (
+      !LogHandler.activity ||
+      this.isManual() ||
+      this.shouldIgnoreActiveActivity('spell cast')
+    ) {
       // Deliberately don't log anything here as we can hit this a lot
       return;
     }
@@ -636,7 +683,7 @@ export default class RetailLogHandler extends LogHandler {
       Flavour.Retail,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async battlegroundEnd(line: LogLine) {
@@ -647,8 +694,13 @@ export default class RetailLogHandler extends LogHandler {
       return;
     }
 
+    if (!this.ownsActiveActivity()) {
+      await this.endActivityForSource('battleground end');
+      return;
+    }
+
     const endTime = line.date();
     LogHandler.activity.end(endTime, false);
-    await LogHandler.endActivity();
+    await this.endActivityForSource('battleground end');
   }
 }


### PR DESCRIPTION
## Summary

- Track the active combat log source that owns the current recording.
- Ignore source-specific timeout, force-stop, start, end, and metadata mutation events from other log sources.
- Wire Retail PTR and Classic PTR handlers with distinct sources so PTR events cannot stop or mutate base-client recordings.

## Validation

- `git diff --check HEAD`
- TypeScript syntax transpile check for the five changed files
- Local manual append test with real `CombatLogWatcher` and temporary Retail/Classic `WoWCombatLog.txt` files: Classic timeout was ignored for an active Retail recording, and Retail `ENCOUNTER_END` still stopped the Retail recording.

## Notes

- No test files are included in this PR.
