### PR TITLE
fix: ignore timeouts from other log flavours

### DIFF
--- a/src/main/Manager.ts
+++ b/src/main/Manager.ts
@@ -516,6 +516,7 @@ export default class Manager {
     if (config.recordClassicPtr) {
       this.classicPtrLogHandler = new ClassicLogHandler(
         config.classicPtrLogPath,
+        'classicPtr',
       );
     }
 
@@ -524,7 +525,10 @@ export default class Manager {
     }
 
     if (config.recordRetailPtr) {
-      this.retailPtrLogHandler = new RetailLogHandler(config.retailPtrLogPath);
+      this.retailPtrLogHandler = new RetailLogHandler(
+        config.retailPtrLogPath,
+        'retailPtr',
+      );
       this.retailPtrLogHandler.setIsPtr();
     }
   }

--- a/src/parsing/ClassicLogHandler.ts
+++ b/src/parsing/ClassicLogHandler.ts
@@ -5,7 +5,7 @@ import {
   classicUniqueSpecSpells,
   mopChallengeModes,
 } from '../main/constants';
-import LogHandler from './LogHandler';
+import LogHandler, { type LogHandlerSource } from './LogHandler';
 import { Flavour } from '../main/types';
 import ArenaMatch from '../activitys/ArenaMatch';
 import { isUnitFriendly, isUnitPlayer, isUnitSelf } from './logutils';
@@ -20,8 +20,8 @@ import ConfigService from 'config/ConfigService';
  * Classic log handler class.
  */
 export default class ClassicLogHandler extends LogHandler {
-  constructor(logPath: string) {
-    super(logPath, 2);
+  constructor(logPath: string, source: LogHandlerSource = 'classic') {
+    super(logPath, 2, source);
 
     /* eslint-disable prettier/prettier */
     this.combatLogWatcher
@@ -217,7 +217,7 @@ export default class ClassicLogHandler extends LogHandler {
       Flavour.Classic,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private static calculateArenaResult(arenaMatch: ArenaMatch) {
@@ -381,7 +381,7 @@ export default class ClassicLogHandler extends LogHandler {
       Flavour.Classic,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async battlegroundEnd(line: LogLine) {
@@ -489,7 +489,7 @@ export default class ClassicLogHandler extends LogHandler {
       Flavour.Classic,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async handleChallengeModeEndLine(line: LogLine) {

--- a/src/parsing/EraLogHandler.ts
+++ b/src/parsing/EraLogHandler.ts
@@ -10,7 +10,7 @@ import { classicUniqueSpecSpells } from '../main/constants';
  */
 export default class EraLogHandler extends LogHandler {
   constructor(logPath: string) {
-    super(logPath, 2);
+    super(logPath, 2, 'era');
 
     /* eslint-disable prettier/prettier */
     this.combatLogWatcher

--- a/src/parsing/LogHandler.ts
+++ b/src/parsing/LogHandler.ts
@@ -42,12 +42,25 @@ import { ESupportedEncoders } from 'main/obsEnums';
  * typically have up to 4 child classes, we don't want multiple concurrent
  * activities.
  */
+export type LogHandlerSource =
+  | 'retail'
+  | 'retailPtr'
+  | 'classic'
+  | 'classicPtr'
+  | 'era';
+
 export default abstract class LogHandler {
   public static activity: Activity | undefined;
+
+  // Tracks which watcher started the shared activity so only that watcher's
+  // timeout can end it. Global force stops deliberately ignore this.
+  private static activitySource: LogHandlerSource | undefined;
 
   public static overrunning = false;
 
   public combatLogWatcher: CombatLogWatcher;
+
+  protected readonly source: LogHandlerSource;
 
   protected player: Combatant | undefined;
 
@@ -60,7 +73,8 @@ export default abstract class LogHandler {
    */
   protected logProcessQueue = new AsyncQueue(Number.MAX_SAFE_INTEGER);
 
-  constructor(logPath: string, dataTimeout: number) {
+  constructor(logPath: string, dataTimeout: number, source: LogHandlerSource) {
+    this.source = source;
     this.combatLogWatcher = new CombatLogWatcher(logPath, dataTimeout);
     this.combatLogWatcher.watch();
     const lpq = this.logProcessQueue;
@@ -124,7 +138,7 @@ export default abstract class LogHandler {
       flavour,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   protected async handleEncounterEndLine(line: LogLine) {
@@ -208,7 +222,15 @@ export default abstract class LogHandler {
     LogHandler.activity.addDeath(playerDeath);
   }
 
-  protected static async startActivity(activity: Activity) {
+  // Instance starts tag the shared activity with this watcher's source.
+  protected async startActivity(activity: Activity) {
+    await LogHandler.startActivity(activity, this.source);
+  }
+
+  protected static async startActivity(
+    activity: Activity,
+    source?: LogHandlerSource,
+  ) {
     const { category } = activity;
     const allowed = allowRecordCategory(ConfigService.getInstance(), category);
 
@@ -230,11 +252,13 @@ export default abstract class LogHandler {
 
     try {
       LogHandler.activity = activity;
+      LogHandler.activitySource = source;
       await Recorder.getInstance().startRecording(offset);
       LogHandler.stateChangeCallback();
     } catch (error) {
       console.error('[LogHandler] Error starting activity', String(error));
       LogHandler.activity = undefined;
+      LogHandler.activitySource = undefined;
     }
   }
 
@@ -258,6 +282,7 @@ export default abstract class LogHandler {
     const lastActivity = LogHandler.activity;
     LogHandler.overrunning = true;
     LogHandler.activity = undefined;
+    LogHandler.activitySource = undefined;
 
     const { overrun } = lastActivity;
 
@@ -364,9 +389,33 @@ export default abstract class LogHandler {
       } seconds.`,
     );
 
-    if (LogHandler.activity) {
-      await LogHandler.forceEndActivity(-ms / 1000);
+    if (!LogHandler.activity) {
+      return;
     }
+
+    // Manual recordings are not owned by any combat log watcher. Only
+    // explicit/global stop paths should end them.
+    if (this.isManual()) {
+      console.info('[LogHandler] Ignoring timeout while in manual recording');
+      return;
+    }
+
+    // Timeouts belong to one combat log watcher, while activity is shared
+    // globally. Ignore stale timeouts from another watcher/source.
+    if (
+      LogHandler.activitySource &&
+      LogHandler.activitySource !== this.source
+    ) {
+      console.info(
+        '[LogHandler] Ignoring timeout from',
+        this.source,
+        'log while recording',
+        LogHandler.activitySource,
+      );
+      return;
+    }
+
+    await LogHandler.forceEndActivity(-ms / 1000);
   }
 
   public static async forceEndActivity(timedelta = 0) {
@@ -388,6 +437,7 @@ export default abstract class LogHandler {
   public static dropActivity() {
     LogHandler.overrunning = false;
     LogHandler.activity = undefined;
+    LogHandler.activitySource = undefined;
   }
 
   protected async zoneChangeStop(line: LogLine) {

--- a/src/parsing/RetailLogHandler.ts
+++ b/src/parsing/RetailLogHandler.ts
@@ -11,7 +11,7 @@ import {
 } from '../main/constants';
 
 import ArenaMatch from '../activitys/ArenaMatch';
-import LogHandler from './LogHandler';
+import LogHandler, { type LogHandlerSource } from './LogHandler';
 import Battleground from '../activitys/Battleground';
 import ChallengeModeDungeon from '../activitys/ChallengeModeDungeon';
 
@@ -34,8 +34,8 @@ import RaidEncounter from 'activitys/RaidEncounter';
 export default class RetailLogHandler extends LogHandler {
   private isPtr = false;
 
-  constructor(logPath: string) {
-    super(logPath, 10);
+  constructor(logPath: string, source: LogHandlerSource = 'retail') {
+    super(logPath, 10, source);
 
     /* eslint-disable prettier/prettier */
     this.combatLogWatcher
@@ -105,7 +105,7 @@ export default class RetailLogHandler extends LogHandler {
     if (!LogHandler.activity && category === VideoCategory.SoloShuffle) {
       console.info('[RetailLogHandler] Fresh Solo Shuffle game starting');
       const activity = new SoloShuffle(startTime, zoneID);
-      await LogHandler.startActivity(activity);
+      await this.startActivity(activity);
     } else if (LogHandler.activity && category === VideoCategory.SoloShuffle) {
       console.info(
         '[RetailLogHandler] New round of existing Solo Shuffle starting',
@@ -122,7 +122,7 @@ export default class RetailLogHandler extends LogHandler {
         Flavour.Retail,
       );
 
-      await LogHandler.startActivity(activity);
+      await this.startActivity(activity);
     }
   }
 
@@ -223,7 +223,7 @@ export default class RetailLogHandler extends LogHandler {
     );
 
     activity.addTimelineSegment(initialSegment);
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async handleChallengeModeEndLine(line: LogLine) {
@@ -635,7 +635,7 @@ export default class RetailLogHandler extends LogHandler {
       Flavour.Retail,
     );
 
-    await LogHandler.startActivity(activity);
+    await this.startActivity(activity);
   }
 
   private async battlegroundEnd(line: LogLine) {


### PR DESCRIPTION
Fixes #855.

This is a smaller replacement for #858.

The previous approach tried to model ownership at the log handler/source level, which added more complexity than this bug needs. This version uses the existing `Activity.flavour` instead.

A combat log timeout now only force-ends the active recording when the timeout comes from the same game flavour as the active activity. For example, a Classic timeout will no longer end a Retail recording.

This keeps:
- `LogHandler.activity` static
- global `forceEndActivity()` behavior unchanged
- `WARCRAFT_RECORDER_FORCE_STOP` behavior unchanged

Validation:
- `npx eslint src/parsing/LogHandler.ts src/parsing/RetailLogHandler.ts src/parsing/ClassicLogHandler.ts src/parsing/EraLogHandler.ts`
- local append-event simulation using real `WoWCombatLog.txt` writes:
  - Classic timeout ignored during Retail recording
  - same-flavour Retail timeout still force-ends recording
  - force-stop event still ends recording globally