### PR TITLE
Handle unknown dungeon map IDs

### DIFF
--- a/src/renderer/rendererutils.ts
+++ b/src/renderer/rendererutils.ts
@@ -321,22 +321,24 @@ const getEncounterNameById = (encounterId: number): string => {
 };
 
 /**
- * Get the dungeon name if possible, else an empty string.
+ * Get the dungeon name if possible, else "Unknown Map".
  */
-const getDungeonName = (video: RendererVideo) => {
+const getDungeonName = (video: RendererVideo): string => {
   const { mapID } = video;
 
   if (mapID === undefined) {
-    return '';
+    return 'Unknown Map';
   }
 
   if (video.flavour === Flavour.Retail) {
-    return dungeonsByMapId[mapID];
+    return dungeonsByMapId[mapID] ?? 'Unknown Map';
   }
 
   if (video.flavour === Flavour.Classic) {
-    return mopChallengeModes[mapID];
+    return mopChallengeModes[mapID] ?? 'Unknown Map';
   }
+
+  return 'Unknown Map';
 };
 
 const isMythicPlusUtil = (video: RendererVideo) => {


### PR DESCRIPTION
## Summary

- Make `getDungeonName` always return a string.
- Fall back to `"Unknown Map"` when a dungeon map ID cannot be resolved.

## Why

The current recording path rejects unknown map IDs, but persisted or cloud metadata is loaded without runtime validation. If it contains an unrecognized map ID, `getDungeonName` previously returned `undefined`. Clip activity sorting later calls `localeCompare` on the returned value, which could throw and break the clips table.

## Validation

- Local regression checks for unknown Retail and Classic map IDs and clip sorting.
- `npm run build:renderer`
- Targeted ESLint and Prettier checks for the changed file.
- `git diff --check`
