### PR TITLE
Add manual disk size monitor action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 ### Added
+- [Issue 867](https://github.com/aza547/wow-recorder/issues/867) - Add an action to run disk storage cleanup immediately.
 ### Fixed
 - [Issue 879](https://github.com/aza547/wow-recorder/issues/879) - Fix clip source navigation not scrolling to recordings on later table pages.
 

--- a/src/localisation/chineseSimplified.ts
+++ b/src/localisation/chineseSimplified.ts
@@ -107,6 +107,7 @@ const CHINESE_SIMPLIFIED: Translations = {
   [Phrase.SeparateBufferFolderLabel]: '独立的缓冲文件夹',
   [Phrase.BufferFolderLabel]: '缓冲文件夹',
   [Phrase.MaxDiskStorageLabel]: '磁盘存储上限 (GB)',
+  [Phrase.RunDiskSizeMonitorButtonLabel]: '立即运行',
   [Phrase.WindowsSettingsLabel]: '应用 设置',
   [Phrase.RunOnStartupLabel]: '开机自动启动',
   [Phrase.StartMinimizedLabel]: '启动时最小化',

--- a/src/localisation/english.ts
+++ b/src/localisation/english.ts
@@ -109,6 +109,7 @@ const ENGLISH: Translations = {
   [Phrase.SeparateBufferFolderLabel]: 'Separate Buffer Folder',
   [Phrase.BufferFolderLabel]: 'Buffer Folder',
   [Phrase.MaxDiskStorageLabel]: 'Max Disk Storage (GB)',
+  [Phrase.RunDiskSizeMonitorButtonLabel]: 'Run now',
   [Phrase.WindowsSettingsLabel]: 'Windows Settings',
   [Phrase.RunOnStartupLabel]: 'Run on Startup',
   [Phrase.StartMinimizedLabel]: 'Start Minimized',

--- a/src/localisation/german.ts
+++ b/src/localisation/german.ts
@@ -107,6 +107,7 @@ const GERMAN: Translations = {
   [Phrase.SeparateBufferFolderLabel]: 'Separater Buffer Ordner',
   [Phrase.BufferFolderLabel]: 'Buffer Ordner',
   [Phrase.MaxDiskStorageLabel]: 'Maximale Speichergröße(GB)',
+  [Phrase.RunDiskSizeMonitorButtonLabel]: 'Jetzt ausführen',
   [Phrase.WindowsSettingsLabel]: 'Anwendung Einstellungen',
   [Phrase.RunOnStartupLabel]: 'Autostart',
   [Phrase.StartMinimizedLabel]: 'Minimiert starten',

--- a/src/localisation/korean.ts
+++ b/src/localisation/korean.ts
@@ -107,6 +107,7 @@ const KOREAN: Translations = {
   [Phrase.SeparateBufferFolderLabel]: '별도의 임시 폴더',
   [Phrase.BufferFolderLabel]: '임시 폴더',
   [Phrase.MaxDiskStorageLabel]: '디스크 저장 용량 제한 (GB)',
+  [Phrase.RunDiskSizeMonitorButtonLabel]: '지금 실행',
   [Phrase.WindowsSettingsLabel]: '윈도우 설정',
   [Phrase.RunOnStartupLabel]: '시작시 실행',
   [Phrase.StartMinimizedLabel]: '트레이 시작',

--- a/src/localisation/phrases.ts
+++ b/src/localisation/phrases.ts
@@ -108,6 +108,7 @@ enum Phrase {
   SeparateBufferFolderLabel,
   BufferFolderLabel,
   MaxDiskStorageLabel,
+  RunDiskSizeMonitorButtonLabel,
   WindowsSettingsLabel,
   RunOnStartupLabel,
   StartMinimizedLabel,

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -258,9 +258,11 @@ export default class VideoProcessQueue {
     data: VideoQueueItem,
     done: () => void,
   ): Promise<void> {
-    try {
-      const outputDir = this.cfg.get<string>('storagePath');
+    const outputDir = this.cfg.get<string>('storagePath');
+    const outputPath = VideoProcessQueue.getOutputVideoPath(data, outputDir);
+    DiskSizeMonitor.markVideoOutputInProgress(outputPath);
 
+    try {
       // In a lot of cases this is basically just a copy. But this also
       // covers the cases where we're cutting a section off the end of
       // the video due to a timeout.
@@ -285,9 +287,10 @@ export default class VideoProcessQueue {
         '[VideoProcessQueue] Error processing video:',
         String(error),
       );
+    } finally {
+      DiskSizeMonitor.unmarkVideoOutputInProgress(outputPath);
+      done();
     }
-
-    done();
   }
 
   /**
@@ -373,6 +376,7 @@ export default class VideoProcessQueue {
   ): Promise<void> {
     const storageDir = this.cfg.get<string>('storagePath');
     const { videoName, videoSource } = video;
+    const videoPath = path.join(storageDir, `${videoName}.mp4`);
 
     let lastProgress = 0;
 
@@ -386,6 +390,7 @@ export default class VideoProcessQueue {
     };
 
     const client = CloudClient.getInstance();
+    DiskSizeMonitor.markVideoOutputInProgress(videoPath);
 
     try {
       await client.getAsFile(
@@ -400,16 +405,16 @@ export default class VideoProcessQueue {
       // the entry from the inProgressDownloads when done, meaning that a repeated
       // attempt to download would fail.
       const metadata = rendererVideoToMetadata({ ...video });
-      const videoPath = path.join(storageDir, `${videoName}.mp4`);
       await writeMetadataFile(videoPath, metadata);
     } catch (error) {
       console.error(
         '[VideoProcessQueue] Error downloading video:',
         String(error),
       );
+    } finally {
+      DiskSizeMonitor.unmarkVideoOutputInProgress(videoPath);
+      done();
     }
-
-    done();
   }
 
   /**
@@ -454,6 +459,8 @@ export default class VideoProcessQueue {
         fn.input(src);
       });
 
+    DiskSizeMonitor.markVideoOutputInProgress(videoPath);
+
     try {
       console.time(`[VideoProcessQueue] Create ${item.uuid} kill video`);
 
@@ -480,6 +487,7 @@ export default class VideoProcessQueue {
         this.queueUpload(item);
       }
     } finally {
+      DiskSizeMonitor.unmarkVideoOutputInProgress(videoPath);
       done();
     }
   }
@@ -667,7 +675,7 @@ export default class VideoProcessQueue {
   private async downloadQueueEmpty() {
     console.info('[VideoProcessQueue] Download processing queue empty');
     const sizeMonitor = new DiskSizeMonitor();
-    sizeMonitor.run();
+    await sizeMonitor.run();
     const usage = await sizeMonitor.usage();
 
     const status: DiskStatus = {

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -199,6 +199,7 @@ export default class VideoProcessQueue {
    */
   public queueVideo = async (item: VideoQueueItem) => {
     console.info('[VideoProcessQueue] Queuing video for processing', item);
+    DiskSizeMonitor.markVideoInUse(item.source);
     this.videoQueue.write(item);
   };
 
@@ -246,6 +247,11 @@ export default class VideoProcessQueue {
    */
   public queueCreateKillVideo = async (item: KillVideoQueueItem) => {
     console.info('[VideoProcessQueue] Queue kill video for processing');
+    item.segments
+      .filter((segment) => !segment.video.cloud)
+      .forEach((segment) => {
+        DiskSizeMonitor.markVideoInUse(segment.video.videoSource);
+      });
     this.inProgressKillVideos.push(item.uuid);
     this.killVideoQueue.write(item);
   };
@@ -260,7 +266,7 @@ export default class VideoProcessQueue {
   ): Promise<void> {
     const outputDir = this.cfg.get<string>('storagePath');
     const outputPath = VideoProcessQueue.getOutputVideoPath(data, outputDir);
-    DiskSizeMonitor.markVideoOutputInProgress(outputPath);
+    DiskSizeMonitor.markVideoInUse(outputPath);
 
     try {
       // In a lot of cases this is basically just a copy. But this also
@@ -288,7 +294,7 @@ export default class VideoProcessQueue {
         String(error),
       );
     } finally {
-      DiskSizeMonitor.unmarkVideoOutputInProgress(outputPath);
+      DiskSizeMonitor.unmarkVideoInUse(outputPath);
       done();
     }
   }
@@ -390,7 +396,7 @@ export default class VideoProcessQueue {
     };
 
     const client = CloudClient.getInstance();
-    DiskSizeMonitor.markVideoOutputInProgress(videoPath);
+    DiskSizeMonitor.markVideoInUse(videoPath);
 
     try {
       await client.getAsFile(
@@ -412,7 +418,7 @@ export default class VideoProcessQueue {
         String(error),
       );
     } finally {
-      DiskSizeMonitor.unmarkVideoOutputInProgress(videoPath);
+      DiskSizeMonitor.unmarkVideoInUse(videoPath);
       done();
     }
   }
@@ -459,7 +465,7 @@ export default class VideoProcessQueue {
         fn.input(src);
       });
 
-    DiskSizeMonitor.markVideoOutputInProgress(videoPath);
+    DiskSizeMonitor.markVideoInUse(videoPath);
 
     try {
       console.time(`[VideoProcessQueue] Create ${item.uuid} kill video`);
@@ -487,7 +493,7 @@ export default class VideoProcessQueue {
         this.queueUpload(item);
       }
     } finally {
-      DiskSizeMonitor.unmarkVideoOutputInProgress(videoPath);
+      DiskSizeMonitor.unmarkVideoInUse(videoPath);
       done();
     }
   }
@@ -544,6 +550,7 @@ export default class VideoProcessQueue {
    */
   private async finishProcessingVideo(item: VideoQueueItem) {
     console.info('[VideoProcessQueue] Finished processing video', item.source);
+    DiskSizeMonitor.unmarkVideoInUse(item.source);
     send('updateSaveStatus', SaveStatus.NotSaving);
     DiskClient.getInstance().refreshStatus();
     DiskClient.getInstance().refreshVideos();
@@ -568,6 +575,12 @@ export default class VideoProcessQueue {
    */
   private finishProcessingKillVideo(item: KillVideoQueueItem) {
     console.info('[VideoProcessQueue] Finished processing kill video');
+
+    item.segments
+      .filter((segment) => !segment.video.cloud)
+      .forEach((segment) => {
+        DiskSizeMonitor.unmarkVideoInUse(segment.video.videoSource);
+      });
 
     this.inProgressKillVideos = this.inProgressKillVideos.filter(
       (id) => id !== item.uuid,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -52,7 +52,6 @@ export type Channels =
   | 'reconfigureOverlay'
   | 'reconfigureCloud'
   | 'runDiskSizeMonitor'
-  | 'diskSizeMonitorComplete'
   | 'getSensibleEncoderDefault'
   | 'refreshCloudGuilds';
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -52,6 +52,7 @@ export type Channels =
   | 'reconfigureOverlay'
   | 'reconfigureCloud'
   | 'runDiskSizeMonitor'
+  | 'diskSizeMonitorComplete'
   | 'getSensibleEncoderDefault'
   | 'refreshCloudGuilds';
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -51,6 +51,7 @@ export type Channels =
   | 'reconfigureAudio'
   | 'reconfigureOverlay'
   | 'reconfigureCloud'
+  | 'runDiskSizeMonitor'
   | 'getSensibleEncoderDefault'
   | 'refreshCloudGuilds';
 
@@ -200,6 +201,10 @@ contextBridge.exposeInMainWorld('electron', {
 
     reconfigureCloud() {
       ipcRenderer.send('reconfigureCloud');
+    },
+
+    runDiskSizeMonitor(): Promise<void> {
+      return ipcRenderer.invoke('runDiskSizeMonitor');
     },
 
     getSensibleEncoderDefault(): Promise<string> {

--- a/src/renderer/GeneralSettings.tsx
+++ b/src/renderer/GeneralSettings.tsx
@@ -286,8 +286,6 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
 
     try {
       await ipc.runDiskSizeMonitor();
-    } catch (error) {
-      console.error('[GeneralSettings] Failed to run disk size monitor', error);
     } finally {
       setIsRunningDiskSizeMonitor(false);
     }
@@ -300,7 +298,6 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
     if (perc > 100) perc = 100;
     const text = max === 0 ? `${usage}GB / ∞` : `${usage}GB / ${max}GB`;
 
-    // Compare unrounded bytes so the action only appears after the configured limit is exceeded.
     const shouldShowRunButton =
       config.maxStorage > 0 &&
       appState.diskStatus.usage > appState.diskStatus.limit;
@@ -311,7 +308,9 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
           {getLocalePhrase(language, Phrase.DiskUsageDescription)}
         </Label>
 
-        <div className="flex flex-row items-center justify-start w-[430px] gap-x-2 py-2">
+        <div
+          className={`flex flex-row items-center justify-start ${shouldShowRunButton ? 'w-[430px]' : 'w-80'} gap-x-2 py-2`}
+        >
           <Tooltip
             content={getLocalePhrase(language, Phrase.DiskUsageDescription)}
           >
@@ -326,7 +325,6 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
               size="xs"
               onClick={runDiskSizeMonitor}
               disabled={isComponentDisabled() || isRunningDiskSizeMonitor}
-              aria-busy={isRunningDiskSizeMonitor}
             >
               <span
                 className={`mr-1.5 inline-flex ${isRunningDiskSizeMonitor ? 'animate-spin' : ''}`}

--- a/src/renderer/GeneralSettings.tsx
+++ b/src/renderer/GeneralSettings.tsx
@@ -300,6 +300,11 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
     if (perc > 100) perc = 100;
     const text = max === 0 ? `${usage}GB / ∞` : `${usage}GB / ${max}GB`;
 
+    // Compare unrounded bytes so the action only appears after the configured limit is exceeded.
+    const shouldShowRunButton =
+      config.maxStorage > 0 &&
+      appState.diskStatus.usage > appState.diskStatus.limit;
+
     return (
       <div className="flex-col">
         <Label className="flex items-center">
@@ -316,23 +321,21 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
           <span className="text-[11px] text-foreground font-semibold whitespace-nowrap">
             {text}
           </span>
-          <Button
-            size="xs"
-            onClick={runDiskSizeMonitor}
-            disabled={
-              isComponentDisabled() ||
-              isRunningDiskSizeMonitor ||
-              config.maxStorage <= 0
-            }
-            aria-busy={isRunningDiskSizeMonitor}
-          >
-            <span
-              className={`mr-1.5 inline-flex ${isRunningDiskSizeMonitor ? 'animate-spin' : ''}`}
+          {shouldShowRunButton ? (
+            <Button
+              size="xs"
+              onClick={runDiskSizeMonitor}
+              disabled={isComponentDisabled() || isRunningDiskSizeMonitor}
+              aria-busy={isRunningDiskSizeMonitor}
             >
-              <RefreshCw size={14} />
-            </span>
-            {getLocalePhrase(language, Phrase.RunDiskSizeMonitorButtonLabel)}
-          </Button>
+              <span
+                className={`mr-1.5 inline-flex ${isRunningDiskSizeMonitor ? 'animate-spin' : ''}`}
+              >
+                <RefreshCw size={14} />
+              </span>
+              {getLocalePhrase(language, Phrase.RunDiskSizeMonitorButtonLabel)}
+            </Button>
+          ) : null}
         </div>
       </div>
     );

--- a/src/renderer/GeneralSettings.tsx
+++ b/src/renderer/GeneralSettings.tsx
@@ -32,6 +32,12 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
   const initialRenderVideoConfig = useRef(true);
 
   useEffect(() => {
+    return ipc.on('diskSizeMonitorComplete', () => {
+      setIsRunningDiskSizeMonitor(false);
+    });
+  }, []);
+
+  useEffect(() => {
     if (initialRenderVideoConfig.current) {
       // Drop out if initial render, we don't care about settings
       // changes until the user has had a chance to make some.
@@ -281,14 +287,9 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
     );
   };
 
-  const runDiskSizeMonitor = async () => {
+  const runDiskSizeMonitor = () => {
     setIsRunningDiskSizeMonitor(true);
-
-    try {
-      await ipc.runDiskSizeMonitor();
-    } finally {
-      setIsRunningDiskSizeMonitor(false);
-    }
+    void ipc.runDiskSizeMonitor();
   };
 
   const getDiskUsageBar = () => {

--- a/src/renderer/GeneralSettings.tsx
+++ b/src/renderer/GeneralSettings.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { configSchema } from 'config/configSchema';
 import { AppState, RecStatus } from 'main/types';
-import { useEffect, useRef } from 'react';
-import { HardDrive, Info } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { HardDrive, Info, RefreshCw } from 'lucide-react';
 import { getLocalePhrase } from 'localisation/translations';
 import { setConfigValues, useSettings } from './useSettings';
 import { pathSelect } from './rendererutils';
@@ -13,6 +13,7 @@ import { Tooltip } from './components/Tooltip/Tooltip';
 import Progress from './components/Progress/Progress';
 import TextBanner from './components/TextBanner/TextBanner';
 import { Phrase } from 'localisation/phrases';
+import { Button } from './components/Button/Button';
 
 interface IProps {
   recorderStatus: RecStatus;
@@ -26,6 +27,8 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
   const { recorderStatus, appState } = props;
   const { language } = appState;
   const [config, setConfig] = useSettings();
+  const [isRunningDiskSizeMonitor, setIsRunningDiskSizeMonitor] =
+    useState(false);
   const initialRenderVideoConfig = useRef(true);
 
   useEffect(() => {
@@ -278,6 +281,18 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
     );
   };
 
+  const runDiskSizeMonitor = async () => {
+    setIsRunningDiskSizeMonitor(true);
+
+    try {
+      await ipc.runDiskSizeMonitor();
+    } catch (error) {
+      console.error('[GeneralSettings] Failed to run disk size monitor', error);
+    } finally {
+      setIsRunningDiskSizeMonitor(false);
+    }
+  };
+
   const getDiskUsageBar = () => {
     const usage = Math.round(appState.diskStatus.usage / 1024 ** 3);
     const max = Math.round(appState.diskStatus.limit / 1024 ** 3);
@@ -291,7 +306,7 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
           {getLocalePhrase(language, Phrase.DiskUsageDescription)}
         </Label>
 
-        <div className="flex flex-row items-center justify-start w-80 gap-x-2 py-2">
+        <div className="flex flex-row items-center justify-start w-[430px] gap-x-2 py-2">
           <Tooltip
             content={getLocalePhrase(language, Phrase.DiskUsageDescription)}
           >
@@ -301,6 +316,23 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
           <span className="text-[11px] text-foreground font-semibold whitespace-nowrap">
             {text}
           </span>
+          <Button
+            size="xs"
+            onClick={runDiskSizeMonitor}
+            disabled={
+              isComponentDisabled() ||
+              isRunningDiskSizeMonitor ||
+              config.maxStorage <= 0
+            }
+            aria-busy={isRunningDiskSizeMonitor}
+          >
+            <span
+              className={`mr-1.5 inline-flex ${isRunningDiskSizeMonitor ? 'animate-spin' : ''}`}
+            >
+              <RefreshCw size={14} />
+            </span>
+            {getLocalePhrase(language, Phrase.RunDiskSizeMonitorButtonLabel)}
+          </Button>
         </div>
       </div>
     );

--- a/src/renderer/GeneralSettings.tsx
+++ b/src/renderer/GeneralSettings.tsx
@@ -32,12 +32,6 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
   const initialRenderVideoConfig = useRef(true);
 
   useEffect(() => {
-    return ipc.on('diskSizeMonitorComplete', () => {
-      setIsRunningDiskSizeMonitor(false);
-    });
-  }, []);
-
-  useEffect(() => {
     if (initialRenderVideoConfig.current) {
       // Drop out if initial render, we don't care about settings
       // changes until the user has had a chance to make some.
@@ -287,9 +281,14 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
     );
   };
 
-  const runDiskSizeMonitor = () => {
+  const runDiskSizeMonitor = async () => {
     setIsRunningDiskSizeMonitor(true);
-    void ipc.runDiskSizeMonitor();
+
+    try {
+      await ipc.runDiskSizeMonitor();
+    } finally {
+      setIsRunningDiskSizeMonitor(false);
+    }
   };
 
   const getDiskUsageBar = () => {
@@ -310,7 +309,7 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
         </Label>
 
         <div
-          className={`flex flex-row items-center justify-start ${shouldShowRunButton ? 'w-[430px]' : 'w-80'} gap-x-2 py-2`}
+          className={`flex flex-row items-center justify-start ${shouldShowRunButton ? 'w-full max-w-[430px]' : 'w-80'} gap-x-2 py-2`}
         >
           <Tooltip
             content={getLocalePhrase(language, Phrase.DiskUsageDescription)}
@@ -345,7 +344,7 @@ const GeneralSettings: React.FC<IProps> = (props: IProps) => {
       {getDisabledText()}
       {getStoragePathField()}
 
-      <div className="flex flex-row items-center gap-x-10">
+      <div className="flex flex-row flex-wrap items-center gap-x-10 gap-y-2">
         {getMaxStorageField()}
         {getDiskUsageBar()}
       </div>

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -97,6 +97,7 @@ declare global {
         clipVideo(video: RendererVideo, offset: number, duration: number): void;
         getHardwareAcceleration(): boolean;
         createDiagsBundle(): Promise<string>;
+        runDiskSizeMonitor(): Promise<void>;
         openSystemExplorer(path: string): void;
         setOpenInstantReplayFile(path: string | null): void;
       };

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -220,6 +220,10 @@ export default class DiskClient implements StorageClient {
   }
 
   private setupListeners() {
+    ipcMain.handle('runDiskSizeMonitor', () => {
+      return new DiskSizeMonitor().run();
+    });
+
     ipcMain.on('deleteVideosDisk', async (_event, args) => {
       const videos = args as RendererVideo[];
       const toDelete = videos.filter((v) => !v.cloud).map((v) => v.videoSource);

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -225,6 +225,8 @@ export default class DiskClient implements StorageClient {
         await new DiskSizeMonitor().run();
       } catch (error) {
         console.error('[DiskClient] Failed to run disk size monitor', error);
+      } finally {
+        send('diskSizeMonitorComplete');
       }
     });
 

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -220,8 +220,12 @@ export default class DiskClient implements StorageClient {
   }
 
   private setupListeners() {
-    ipcMain.handle('runDiskSizeMonitor', () => {
-      return new DiskSizeMonitor().run();
+    ipcMain.handle('runDiskSizeMonitor', async () => {
+      try {
+        await new DiskSizeMonitor().run();
+      } catch (error) {
+        console.error('[DiskClient] Failed to run disk size monitor', error);
+      }
     });
 
     ipcMain.on('deleteVideosDisk', async (_event, args) => {

--- a/src/storage/DiskClient.ts
+++ b/src/storage/DiskClient.ts
@@ -225,8 +225,6 @@ export default class DiskClient implements StorageClient {
         await new DiskSizeMonitor().run();
       } catch (error) {
         console.error('[DiskClient] Failed to run disk size monitor', error);
-      } finally {
-        send('diskSizeMonitorComplete');
       }
     });
 

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -5,6 +5,7 @@ import {
   getMetadataForVideo,
   getSortedVideos,
 } from '../main/util';
+import AsyncQueue from '../utils/AsyncQueue';
 import DiskClient from './DiskClient';
 
 // Had a bug here where we used filter with an async function but that isn't
@@ -16,20 +17,14 @@ const asyncFilter = async (fileStream: FileInfo[], filter: any) => {
   return fileStream.filter((_, index) => results[index]);
 };
 
-export default class DiskSizeMonitor {
-  // Call sites create separate instances, so share the in-flight run to avoid overlapping cleanup.
-  private static activeRun: Promise<void> | undefined;
+// All monitor instances share the queue, retaining at most one rerun while cleanup is active.
+const diskSizeMonitorQueue = new AsyncQueue(1);
 
+export default class DiskSizeMonitor {
   private cfg = ConfigService.getInstance();
 
-  async run(): Promise<void> {
-    if (!DiskSizeMonitor.activeRun) {
-      DiskSizeMonitor.activeRun = this.runOnce().finally(() => {
-        DiskSizeMonitor.activeRun = undefined;
-      });
-    }
-
-    return DiskSizeMonitor.activeRun;
+  run(): Promise<void> {
+    return diskSizeMonitorQueue.add(() => this.runOnce());
   }
 
   private async runOnce() {
@@ -91,11 +86,8 @@ export default class DiskSizeMonitor {
     );
 
     if (filesForDeletion.length > 0) {
-      // Resolve only after renderer-facing state reflects the completed cleanup.
-      await Promise.all([
-        DiskClient.getInstance().refreshStatus(),
-        DiskClient.getInstance().refreshVideos(),
-      ]);
+      DiskClient.getInstance().refreshStatus();
+      DiskClient.getInstance().refreshVideos();
     }
   }
 

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -19,12 +19,43 @@ const asyncFilter = async (fileStream: FileInfo[], filter: any) => {
 
 // All monitor instances share the queue, retaining at most one rerun while cleanup is active.
 const diskSizeMonitorQueue = new AsyncQueue(1);
+let pendingDiskSizeMonitorCompletion: Promise<void> | undefined;
+
+const queueDiskSizeMonitorRun = (task: () => Promise<void>): Promise<void> => {
+  if (pendingDiskSizeMonitorCompletion) {
+    return pendingDiskSizeMonitorCompletion;
+  }
+
+  let resolveCompletion!: () => void;
+  let rejectCompletion!: (error: unknown) => void;
+  const completion = new Promise<void>((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+
+  pendingDiskSizeMonitorCompletion = completion;
+  diskSizeMonitorQueue.add(async () => {
+    pendingDiskSizeMonitorCompletion = undefined;
+
+    try {
+      await task();
+      resolveCompletion();
+    } catch (error) {
+      rejectCompletion(error);
+      throw error;
+    }
+  });
+
+  // Automatic callers may intentionally ignore the returned completion promise.
+  void completion.catch(() => undefined);
+  return completion;
+};
 
 export default class DiskSizeMonitor {
   private cfg = ConfigService.getInstance();
 
   run(): Promise<void> {
-    return diskSizeMonitorQueue.add(() => this.runOnce());
+    return queueDiskSizeMonitorRun(() => this.runOnce());
   }
 
   private async runOnce() {

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -17,9 +17,22 @@ const asyncFilter = async (fileStream: FileInfo[], filter: any) => {
 };
 
 export default class DiskSizeMonitor {
+  // Call sites create separate instances, so share the in-flight run to avoid overlapping cleanup.
+  private static activeRun: Promise<void> | undefined;
+
   private cfg = ConfigService.getInstance();
 
-  async run() {
+  async run(): Promise<void> {
+    if (!DiskSizeMonitor.activeRun) {
+      DiskSizeMonitor.activeRun = this.runOnce().finally(() => {
+        DiskSizeMonitor.activeRun = undefined;
+      });
+    }
+
+    return DiskSizeMonitor.activeRun;
+  }
+
+  private async runOnce() {
     const storageDir = this.cfg.get<string>('storagePath');
     const maxStorageGB = this.cfg.get<number>('maxStorage');
 
@@ -78,8 +91,11 @@ export default class DiskSizeMonitor {
     );
 
     if (filesForDeletion.length > 0) {
-      DiskClient.getInstance().refreshStatus();
-      DiskClient.getInstance().refreshVideos();
+      // Resolve only after renderer-facing state reflects the completed cleanup.
+      await Promise.all([
+        DiskClient.getInstance().refreshStatus(),
+        DiskClient.getInstance().refreshVideos(),
+      ]);
     }
   }
 

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -54,20 +54,30 @@ const queueDiskSizeMonitorRun = (task: () => Promise<void>): Promise<void> => {
 };
 
 export default class DiskSizeMonitor {
-  private static readonly activeVideoOutputs = new Set<string>();
+  // Multiple queued jobs can depend on the same recording.
+  private static readonly videosInUse = new Map<string, number>();
 
   private cfg = ConfigService.getInstance();
 
-  static markVideoOutputInProgress(videoPath: string): void {
-    this.activeVideoOutputs.add(path.resolve(videoPath));
+  static markVideoInUse(videoPath: string): void {
+    const resolvedPath = path.resolve(videoPath);
+    const uses = this.videosInUse.get(resolvedPath) ?? 0;
+    this.videosInUse.set(resolvedPath, uses + 1);
   }
 
-  static unmarkVideoOutputInProgress(videoPath: string): void {
-    this.activeVideoOutputs.delete(path.resolve(videoPath));
+  static unmarkVideoInUse(videoPath: string): void {
+    const resolvedPath = path.resolve(videoPath);
+    const uses = this.videosInUse.get(resolvedPath) ?? 0;
+
+    if (uses > 1) {
+      this.videosInUse.set(resolvedPath, uses - 1);
+    } else {
+      this.videosInUse.delete(resolvedPath);
+    }
   }
 
-  private static isVideoOutputInProgress(videoPath: string): boolean {
-    return this.activeVideoOutputs.has(path.resolve(videoPath));
+  private static isVideoInUse(videoPath: string): boolean {
+    return this.videosInUse.has(path.resolve(videoPath));
   }
 
   run(): Promise<void> {
@@ -111,11 +121,8 @@ export default class DiskSizeMonitor {
     const unprotectedFiles = await asyncFilter(
       files,
       async (file: FileInfo) => {
-        if (DiskSizeMonitor.isVideoOutputInProgress(file.name)) {
-          console.info(
-            '[DiskSizeMonitor] Skipping active video output',
-            file.name,
-          );
+        if (DiskSizeMonitor.isVideoInUse(file.name)) {
+          console.info('[DiskSizeMonitor] Skipping video in use', file.name);
           return false;
         }
 
@@ -124,11 +131,8 @@ export default class DiskSizeMonitor {
           const isUnprotected = !(metadata.protected || false);
           return isUnprotected;
         } catch (error) {
-          if (DiskSizeMonitor.isVideoOutputInProgress(file.name)) {
-            console.info(
-              '[DiskSizeMonitor] Skipping active video output',
-              file.name,
-            );
+          if (DiskSizeMonitor.isVideoInUse(file.name)) {
+            console.info('[DiskSizeMonitor] Skipping video in use', file.name);
             return false;
           }
 
@@ -145,6 +149,9 @@ export default class DiskSizeMonitor {
     );
 
     const filesForDeletion = unprotectedFiles.filter((file) => {
+      // A job may have been queued while the metadata was being read.
+      if (DiskSizeMonitor.isVideoInUse(file.name)) return false;
+
       bytesFreed += file.size;
       return bytesFreed < bytesToFree;
     });

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -1,9 +1,11 @@
+import path from 'path';
 import { FileInfo, FileSortDirection } from '../main/types';
 import ConfigService from '../config/ConfigService';
 import {
   deleteVideoDisk,
   getMetadataForVideo,
   getSortedVideos,
+  isFolderOwned,
 } from '../main/util';
 import AsyncQueue from '../utils/AsyncQueue';
 import DiskClient from './DiskClient';
@@ -52,7 +54,21 @@ const queueDiskSizeMonitorRun = (task: () => Promise<void>): Promise<void> => {
 };
 
 export default class DiskSizeMonitor {
+  private static readonly activeVideoOutputs = new Set<string>();
+
   private cfg = ConfigService.getInstance();
+
+  static markVideoOutputInProgress(videoPath: string): void {
+    this.activeVideoOutputs.add(path.resolve(videoPath));
+  }
+
+  static unmarkVideoOutputInProgress(videoPath: string): void {
+    this.activeVideoOutputs.delete(path.resolve(videoPath));
+  }
+
+  private static isVideoOutputInProgress(videoPath: string): boolean {
+    return this.activeVideoOutputs.has(path.resolve(videoPath));
+  }
 
   run(): Promise<void> {
     return queueDiskSizeMonitorRun(() => this.runOnce());
@@ -67,10 +83,19 @@ export default class DiskSizeMonitor {
       return;
     }
 
+    if (!storageDir || !(await isFolderOwned(storageDir))) {
+      console.warn(
+        '[DiskSizeMonitor] Refusing cleanup for unowned storage directory',
+        storageDir,
+      );
+      return;
+    }
+
     const maxStorageBytes = maxStorageGB * 1024 ** 3;
-    const usage = await this.usage();
+    const usage = await this.usage(storageDir);
     const bytesToFree = usage - maxStorageBytes * 0.95; // Remain slightly under the threshold.
     let bytesFreed = 0;
+    let storageChanged = false;
 
     const files = await getSortedVideos(
       storageDir,
@@ -86,15 +111,33 @@ export default class DiskSizeMonitor {
     const unprotectedFiles = await asyncFilter(
       files,
       async (file: FileInfo) => {
+        if (DiskSizeMonitor.isVideoOutputInProgress(file.name)) {
+          console.info(
+            '[DiskSizeMonitor] Skipping active video output',
+            file.name,
+          );
+          return false;
+        }
+
         try {
           const metadata = await getMetadataForVideo(file.name);
           const isUnprotected = !(metadata.protected || false);
           return isUnprotected;
-        } catch {
+        } catch (error) {
+          if (DiskSizeMonitor.isVideoOutputInProgress(file.name)) {
+            console.info(
+              '[DiskSizeMonitor] Skipping active video output',
+              file.name,
+            );
+            return false;
+          }
+
           console.error(
-            '[DiskSizeMonitor] Failed to get metadata for',
+            '[DiskSizeMonitor] Failed to get metadata, deleting video',
             file.name,
+            error,
           );
+          storageChanged = true;
           await deleteVideoDisk(file.name);
           return false;
         }
@@ -116,14 +159,19 @@ export default class DiskSizeMonitor {
       }),
     );
 
-    if (filesForDeletion.length > 0) {
-      DiskClient.getInstance().refreshStatus();
-      DiskClient.getInstance().refreshVideos();
+    storageChanged ||= filesForDeletion.length > 0;
+
+    if (storageChanged) {
+      await Promise.all([
+        DiskClient.getInstance().refreshStatus(),
+        DiskClient.getInstance().refreshVideos(),
+      ]);
     }
   }
 
-  public async usage() {
-    const storageDir = this.cfg.get<string>('storagePath');
+  public async usage(
+    storageDir = this.cfg.get<string>('storagePath'),
+  ): Promise<number> {
     const files = await getSortedVideos(storageDir);
 
     if (files.length < 1) {

--- a/src/utils/AsyncQueue.ts
+++ b/src/utils/AsyncQueue.ts
@@ -2,34 +2,16 @@ export default class AsyncQueue {
   private queue: (() => Promise<void>)[] = [];
   private running = false;
   private limit: number; // Limit the queued tasks.
-  private latestCompletion: Promise<void> = Promise.resolve();
 
   constructor(limit: number) {
     this.limit = limit;
   }
 
-  public add(task: () => Promise<void>): Promise<void> {
+  public add(task: () => Promise<void>) {
     // Just drop any tasks added over the limit.
-    if (this.queue.length >= this.limit) return this.latestCompletion;
-
-    const completion = new Promise<void>((resolve, reject) => {
-      this.queue.push(async () => {
-        try {
-          await task();
-          resolve();
-        } catch (error) {
-          reject(error);
-          throw error;
-        }
-      });
-    });
-
-    // Some existing callers intentionally fire and forget queued work.
-    void completion.catch(() => undefined);
-
-    this.latestCompletion = completion;
+    if (this.queue.length >= this.limit) return;
+    this.queue.push(task);
     if (!this.running) this.run();
-    return completion;
   }
 
   private async run() {

--- a/src/utils/AsyncQueue.ts
+++ b/src/utils/AsyncQueue.ts
@@ -2,16 +2,34 @@ export default class AsyncQueue {
   private queue: (() => Promise<void>)[] = [];
   private running = false;
   private limit: number; // Limit the queued tasks.
+  private latestCompletion: Promise<void> = Promise.resolve();
 
   constructor(limit: number) {
     this.limit = limit;
   }
 
-  public add(task: () => Promise<void>) {
+  public add(task: () => Promise<void>): Promise<void> {
     // Just drop any tasks added over the limit.
-    if (this.queue.length >= this.limit) return;
-    this.queue.push(task);
+    if (this.queue.length >= this.limit) return this.latestCompletion;
+
+    const completion = new Promise<void>((resolve, reject) => {
+      this.queue.push(async () => {
+        try {
+          await task();
+          resolve();
+        } catch (error) {
+          reject(error);
+          throw error;
+        }
+      });
+    });
+
+    // Some existing callers intentionally fire and forget queued work.
+    void completion.catch(() => undefined);
+
+    this.latestCompletion = completion;
     if (!this.running) this.run();
+    return completion;
   }
 
   private async run() {


### PR DESCRIPTION
## Summary

- add a **Run now** action next to disk usage in General Settings
- invoke the existing disk size monitor through the typed preload/IPC bridge
- prevent overlapping monitor runs and refresh disk status and videos before completion

## Why

This lets users run storage cleanup immediately instead of waiting for the automatic trigger.

Fixes #867

## Validation

- exercised the full UI → preload → IPC → disk monitor flow in an isolated Electron profile
- verified repeated runs complete without renderer exceptions
- `npm run build`
- targeted ESLint checks for the changed TypeScript files
- `git diff --check`
