### PR TITLE
Keep Instant Replay available during overrun

### DIFF
--- a/src/main/Manager.ts
+++ b/src/main/Manager.ts
@@ -307,7 +307,7 @@ export default class Manager {
 
     if (LogHandler.activity) {
       refreshInstantReplayState(LogHandler.activity);
-    } else {
+    } else if (!inOverrun) {
       resetInstantReplayState();
     }
   }


### PR DESCRIPTION
## What changed

- Preserve the current Instant Replay state while a recording is in overrun.
- Reset Instant Replay normally once the overrun has finished.

Fixes #877.

## Root cause

When an activity ended, `LogHandler.activity` was cleared before the configured overrun completed. `Manager.refreshStatus()` treated the missing activity as a completed recording and reset the renderer's Instant Replay state, even though the recorder was still producing a valid replay during overrun.

## Impact

Instant Replay remains visible and available for the full recording overrun, then disappears when the recorder returns to its ready state.

## Validation

- `npm run build`
- `npx eslint src/main/Manager.ts`
- Temporary regression test against `Manager.refreshStatus()`: failed before the fix and passed after it
- Simulated Mythic raid E2E: recording produced successfully, boss HP metadata was correct, and the UI showed `Overrunning` with an active `Instant Replay` button
