### PR TITLE
Fix clip source navigation scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Added
 ### Fixed
+- [Issue 879](https://github.com/aza547/wow-recorder/issues/879) - Fix clip source navigation not scrolling to recordings on later table pages.
 
 ## [7.12.0] - 2026-08-18
 ### Added

--- a/src/renderer/components/Tables/VideoSelectionTable.tsx
+++ b/src/renderer/components/Tables/VideoSelectionTable.tsx
@@ -193,14 +193,15 @@ const VideoSelectionTable = (props: IProps) => {
       return undefined;
     }
 
-    hasScrolledToSelection.current = true;
     const selectedIndex = table.getSelectedRowModel().rows[0]?.index ?? 0;
     const selectedPageIndex = Math.floor(selectedIndex / pageSize);
 
     if (selectedPageIndex !== pageIndex) {
       table.setPageIndex(selectedPageIndex);
+      return undefined;
     }
 
+    hasScrolledToSelection.current = true;
     const animationFrame = window.requestAnimationFrame(() => {
       if (!selectedRowRef.current) {
         return;


### PR DESCRIPTION
## Summary

- wait for the selected recording's table page to render before scrolling
- keep the one-time automatic scroll from interfering with later manual pagination
- add an Unreleased changelog entry

Fixes #879

## Testing

- `npx eslint src/renderer/components/Tables/VideoSelectionTable.tsx`
- `npm run build`
- `npm run build:renderer`
- Electron E2E with an isolated profile, 205 Manual recordings, and a clip whose source is on page 2:
  - reproduced the bug with the selected row outside the viewport and `scrollTop = 0`
  - verified the fix centers the selected row with `scrollTop = 1639`
  - verified manual pagination still advances to page 3
- `git diff --check`

## Known repository check

`npm run lint` still reports 38 errors and 18 warnings in pre-existing, unrelated files. The changed TypeScript file passes ESLint independently.
