### PR TITLE
Preserve recoverable recordings after unexpected OBS stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Fixed
 - [Issue 879](https://github.com/aza547/wow-recorder/issues/879) - Fix clip source navigation not scrolling to recordings on later table pages.
+- Preserve recoverable partial recordings after an unexpected OBS output failure.
 
 ## [7.12.0] - 2026-08-18
 ### Added

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -179,6 +179,19 @@ export default class Recorder extends EventEmitter {
   private currentFile: string | null = null;
 
   /**
+   * How the current OBS output is expected to stop. This lets us distinguish an
+   * output failure from a stop initiated by the application.
+   */
+  private stopRequest: 'none' | 'save' | 'discard' = 'none';
+
+  /**
+   * A fragmented recording left behind after an unexpected output failure.
+   * Keep this separate from currentFile so it is not exposed as an active
+   * instant replay after OBS has deactivated.
+   */
+  private interruptedRecordingFile: string | null = null;
+
+  /**
    * The instant replay feature lets the user play the fragmented MP4 as it is
    * being written. We don't want to interrupt the viewer by deleting the file
    * while they are watching it.
@@ -1031,11 +1044,16 @@ export default class Recorder extends EventEmitter {
       FileSortDirection.NewestFirst, // This sorting is redundant in this context.
     );
 
-    // Don't delete an open instant replay. The open instant replay path, if
-    // relevant, has already been normalized when set.
+    // Don't delete an open instant replay or an interrupted recording that has
+    // not yet been handed to the processing queue. Both paths are normalized
+    // when set.
     const files = videos
       .map((f) => path.normalize(f.name))
-      .filter((n) => n !== this.openInstantReplayFile);
+      .filter(
+        (n) =>
+          n !== this.openInstantReplayFile &&
+          n !== this.interruptedRecordingFile,
+      );
 
     const promises = files.map(tryUnlink);
     await Promise.all(promises);
@@ -1102,37 +1120,72 @@ export default class Recorder extends EventEmitter {
     }
 
     if (this.obsState === ERecordingState.None) {
+      if (await this.recoverInterruptedRecording()) {
+        return;
+      }
+
       console.info('[Recorder] Already stopped');
       return;
     }
 
     this.stopQueue.empty();
-    noobs.StopRecording();
-    const wrote = this.stopQueue.shift();
+    this.stopRequest = 'save';
 
     try {
-      await Promise.race([wrote, getPromiseBomb(60, 'Failed to stop')]);
-      console.info('[Recorder] Stopped successfully');
-    } catch (error) {
-      console.error('[Recorder]', error, 'will force stop.');
+      noobs.StopRecording();
+      const wrote = this.stopQueue.shift();
 
-      emitErrorReport(
-        'Failed to stop OBS cleanly. This may lead to miscut videos and is typically a symptom of encoder overload.',
-      );
+      try {
+        await Promise.race([wrote, getPromiseBomb(60, 'Failed to stop')]);
+        console.info('[Recorder] Stopped successfully');
+      } catch (error) {
+        console.error('[Recorder]', error, 'will force stop.');
 
-      noobs.ForceStopRecording();
+        emitErrorReport(
+          'Failed to stop OBS cleanly. This may lead to miscut videos and is typically a symptom of encoder overload.',
+        );
 
-      await Promise.race([
-        wrote,
-        getPromiseBomb(3, 'Failed to recover by force stopping'),
-      ]);
+        noobs.ForceStopRecording();
 
-      console.info('[Recorder] Force stopped successfully');
+        await Promise.race([
+          wrote,
+          getPromiseBomb(3, 'Failed to recover by force stopping'),
+        ]);
+
+        console.info('[Recorder] Force stopped successfully');
+      }
+
+      if (!(await this.recoverInterruptedRecording())) {
+        this.lastFile = noobs.GetLastRecording();
+      }
+    } finally {
+      this.stopRequest = 'none';
+    }
+  }
+
+  /**
+   * Promote a preserved fragmented recording so it can enter the normal video
+   * processing flow.
+   */
+  private async recoverInterruptedRecording() {
+    if (!this.interruptedRecordingFile) {
+      return false;
     }
 
-    // Now that we record in MKV we can still attempt to save
-    // a recording here even if we failed to stop cleanly.
-    this.lastFile = noobs.GetLastRecording();
+    const interruptedFile = this.interruptedRecordingFile;
+
+    if (!(await exists(interruptedFile))) {
+      console.error(
+        '[Recorder] Interrupted recording no longer exists:',
+        interruptedFile,
+      );
+      this.interruptedRecordingFile = null;
+      return false;
+    }
+
+    console.warn('[Recorder] Recover interrupted recording:', interruptedFile);
+    this.lastFile = interruptedFile;
+    return true;
   }
 
   /**
@@ -1150,29 +1203,37 @@ export default class Recorder extends EventEmitter {
 
     if (this.obsState === ERecordingState.None) {
       console.info('[Recorder] Already stopped');
+      this.stopRequest = 'none';
+      this.lastFile = null;
+      this.interruptedRecordingFile = null;
       return;
     }
 
     this.stopQueue.empty();
-    noobs.ForceStopRecording();
+    this.stopRequest = 'discard';
 
-    const wrote = this.stopQueue.shift();
+    try {
+      noobs.ForceStopRecording();
+      const wrote = this.stopQueue.shift();
 
-    if (timeout) {
-      // In the normal case we expect to be done within a short timeout,
-      // so enforce that here.
-      const bomb = getPromiseBomb(3, 'Failed to force stop');
-      await Promise.race([wrote, bomb]);
-    } else {
-      // We allow this to be called without a timeout to enable waiting
-      // indefinitely on Windows sleeping. Often the deactivate signal
-      // is not received until Windows wakes, which could be an arbitrary
-      // amount of time later. This isn't perfect as we could in theory
-      // get stuck here forever, but it's hopefully good enough.
-      await wrote;
+      if (timeout) {
+        // In the normal case we expect to be done within a short timeout,
+        // so enforce that here.
+        const bomb = getPromiseBomb(3, 'Failed to force stop');
+        await Promise.race([wrote, bomb]);
+      } else {
+        // We allow this to be called without a timeout to enable waiting
+        // indefinitely on Windows sleeping. Often the deactivate signal
+        // is not received until Windows wakes, which could be an arbitrary
+        // amount of time later. This isn't perfect as we could in theory
+        // get stuck here forever, but it's hopefully good enough.
+        await wrote;
+      }
+    } finally {
+      this.stopRequest = 'none';
+      this.lastFile = null;
+      this.interruptedRecordingFile = null;
     }
-
-    this.lastFile = null;
   }
 
   /**
@@ -1254,15 +1315,35 @@ export default class Recorder extends EventEmitter {
       case EOBSOutputSignal.Start:
         this.startQueue.push(signal);
         this.obsState = ERecordingState.Recording;
+        this.stopRequest = 'none';
         this.currentFile = null;
         this.instantReplayFile = null;
         this.emit('state-change');
         console.info('[Recorder] State is now:', this.obsState);
         break;
 
+      case EOBSOutputSignal.Stop:
+        if (
+          !this.interruptedRecordingFile &&
+          (this.stopRequest === 'none' ||
+            (this.stopRequest === 'save' && signal.code !== 0))
+        ) {
+          this.preserveInterruptedRecording(signal);
+        }
+        break;
+
       case EOBSOutputSignal.Deactivate:
+        if (
+          !this.interruptedRecordingFile &&
+          this.stopRequest === 'none' &&
+          this.currentFile
+        ) {
+          this.preserveInterruptedRecording(signal);
+        }
+
         this.stopQueue.push(signal);
         this.obsState = ERecordingState.None;
+        this.stopRequest = 'none';
         this.currentFile = null;
         this.instantReplayFile = null;
         this.emit('state-change');
@@ -1278,6 +1359,21 @@ export default class Recorder extends EventEmitter {
         console.info('[Recorder] No action needed on this signal');
         break;
     }
+  }
+
+  /**
+   * Preserve the active fragmented recording after OBS stops unexpectedly.
+   */
+  private preserveInterruptedRecording(signal: Signal) {
+    const recordingFile = this.currentFile
+      ? path.normalize(this.currentFile)
+      : null;
+
+    console.error(
+      `[Recorder] OBS output stopped unexpectedly: signal=${signal.id}, code=${signal.code}, error=${signal.error ?? 'none'}, path=${recordingFile ?? 'none'}`,
+    );
+
+    this.interruptedRecordingFile = recordingFile;
   }
 
   /**
@@ -1939,6 +2035,11 @@ export default class Recorder extends EventEmitter {
     console.info('[Recorder] Get and clear last file', this.lastFile);
     const last = this.lastFile;
     this.lastFile = null;
+
+    if (last === this.interruptedRecordingFile) {
+      this.interruptedRecordingFile = null;
+    }
+
     return last;
   }
 }

--- a/src/main/Recorder.ts
+++ b/src/main/Recorder.ts
@@ -1158,8 +1158,13 @@ export default class Recorder extends EventEmitter {
       if (!(await this.recoverInterruptedRecording())) {
         this.lastFile = noobs.GetLastRecording();
       }
-    } finally {
-      this.stopRequest = 'none';
+    } catch (error) {
+      // The caller discards this activity if stopping fails. Late signals must
+      // not attach its file to a subsequent recording.
+      this.stopRequest = 'discard';
+      this.lastFile = null;
+      this.interruptedRecordingFile = null;
+      throw error;
     }
   }
 
@@ -1230,7 +1235,7 @@ export default class Recorder extends EventEmitter {
         await wrote;
       }
     } finally {
-      this.stopRequest = 'none';
+      // Keep the discard request until Deactivate, even if this wait times out.
       this.lastFile = null;
       this.interruptedRecordingFile = null;
     }
@@ -2034,12 +2039,13 @@ export default class Recorder extends EventEmitter {
   public getAndClearLastFile() {
     console.info('[Recorder] Get and clear last file', this.lastFile);
     const last = this.lastFile;
+    const interrupted = last !== null && last === this.interruptedRecordingFile;
     this.lastFile = null;
 
-    if (last === this.interruptedRecordingFile) {
+    if (interrupted) {
       this.interruptedRecordingFile = null;
     }
 
-    return last;
+    return last ? { path: last, interrupted } : null;
   }
 }

--- a/src/main/VideoProcessQueue.ts
+++ b/src/main/VideoProcessQueue.ts
@@ -754,9 +754,43 @@ export default class VideoProcessQueue {
       .outputOption('-movflags +faststart')
       .output(outputPath);
 
+    let timemark: string | undefined;
+
+    if (data.interrupted) {
+      // The activity can continue after OBS stops writing the recording.
+      fn.on('progress', (progress: { timemark: string }) => {
+        timemark = progress.timemark;
+      });
+    }
+
     console.time('[VideoProcessQueue] Video cut took:');
     await VideoProcessQueue.ffmpegWrapper(fn, 'Video cut');
     console.timeEnd('[VideoProcessQueue] Video cut took:');
+
+    if (data.interrupted) {
+      const outputDuration = timemark
+        ? timemark
+            .split(':')
+            .reduce((seconds, part) => seconds * 60 + Number(part), 0)
+        : NaN;
+
+      if (!Number.isFinite(outputDuration) || outputDuration <= 0) {
+        throw new Error(
+          `[VideoProcessQueue] Failed to determine interrupted recording duration for ${outputPath}: invalid FFmpeg timemark ${timemark ?? 'none'}`,
+        );
+      }
+
+      const duration = Math.min(data.duration, outputDuration);
+
+      if (duration !== data.metadata.duration) {
+        console.info(
+          `[VideoProcessQueue] Adjust interrupted recording duration for ${outputPath} from ${data.metadata.duration} to ${duration} seconds`,
+        );
+      }
+
+      data.metadata.duration = duration;
+    }
+
     return outputPath;
   }
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -181,6 +181,7 @@ type VideoQueueItem = {
   offset: number;
   duration: number;
   clip: boolean;
+  interrupted?: boolean;
   metadata: Metadata;
 };
 

--- a/src/parsing/LogHandler.ts
+++ b/src/parsing/LogHandler.ts
@@ -286,7 +286,7 @@ export default abstract class LogHandler {
     const poller = Poller.getInstance();
     const cfg = ConfigService.getInstance();
 
-    let videoFile;
+    let recording;
 
     const stopPromise = recorder.stop(); // Queue the stop.
     const wowRunning = poller.isWowRunning();
@@ -301,7 +301,7 @@ export default abstract class LogHandler {
       // Now await the stop so we get the file from the recorder. Clear it
       // when we do to prevent it being reused.
       await stopPromise;
-      videoFile = recorder.getAndClearLastFile();
+      recording = recorder.getAndClearLastFile();
     } catch (error) {
       console.error(
         '[LogHandler] Failed to stop recording, discarding video',
@@ -315,7 +315,7 @@ export default abstract class LogHandler {
       return;
     }
 
-    if (!videoFile) {
+    if (!recording) {
       console.error('[LogHandler] No video file available');
 
       const report =
@@ -324,6 +324,8 @@ export default abstract class LogHandler {
 
       return;
     }
+
+    const videoFile = recording.path;
 
     try {
       const metadata = lastActivity.getMetadata();
@@ -356,6 +358,7 @@ export default abstract class LogHandler {
         duration,
         metadata,
         clip: false,
+        interrupted: recording.interrupted,
       };
 
       VideoProcessQueue.getInstance().queueVideo(queueItem);


### PR DESCRIPTION
## Summary

When OBS stops unexpectedly during an activity, keep the recoverable fragmented recording and pass it through the existing video processing pipeline when the activity ends. Protect the file from buffer cleanup until it is handed off.

- Distinguish expected saves and discards from native output failures. Keep discard intent after a timeout so late OBS signals cannot attach a previous file to the next recording.
- Carry a temporary interruption flag through the recording handoff. For recovered recordings, use the final timestamp from the existing FFmpeg remux to cap the stored duration before writing metadata once. Normal recordings and clips retain their existing duration behavior.

## Validation

- `npm run build` — main and renderer passed on Node 24.19.0.
- Targeted Recorder checks — passed eight scenarios, including both discard timeout and save/force-stop timeout regressions reproduced on the original PR and fixed by this update.
- Actual `VideoProcessQueue` with bundled FFmpeg — recovered a synthetic six-audio-track fMP4; an 18-second requested duration became 3.02 seconds of metadata for a 3.029-second output. Verified all six audio tracks, one metadata write, shorter requested cuts, unchanged normal/clip durations, and invalid final timestamp handling.
- `npx eslint src/main/Recorder.ts src/main/VideoProcessQueue.ts src/parsing/LogHandler.ts src/main/types.ts` — the same five existing VideoProcessQueue diagnostics as the original PR; the other changed files are clean. A comparison using ESLint on the original and updated source found no new diagnostics.
- `npm run lint` — 38 existing errors and 18 warnings.
- `npm test -- --runInBand` — seven suites fail before running tests. Repeating the command on an archive of the original PR produced identical failed suites and TypeScript diagnostics.
- `git diff --check` and an independent review of the four changed files — passed.

- Native Electron with the application's Recorder, LogHandler, VideoProcessQueue and bundled noobs 0.0.204/OBS, using an isolated profile, static image source and a small main-window/IPC shim:
  - Terminated only the verified test child `obs-ffmpeg-mux.exe`; observed duplicate `Stop(-8)` signals and `Deactivate`. The original PR stored 10.95 seconds for a 3.067-second file; the update stored a conservative 2.88 seconds. All six audio streams were preserved.
  - Completed a subsequent normal recording in the same Electron instance, with a distinct file and unchanged normal duration behavior.
  - Delayed delivery of native Stop/Deactivate signals by 4.5 seconds to cross the force-stop timeout. The original PR returned the discarded first file for the second activity; the update returned the correct second file.

Packaging, live WoW capture and renderer UI interactions were not tested.

The [CI run for this update](https://github.com/aza547/wow-recorder/actions/runs/34103995536) failed during dependency installation, before Build: the tested merge inherits `noobs@0.0.205` with `resolved: file:../../../warcraft-recorder-obs-engine/noobs-0.0.205.tgz` from its base branch, and that archive is absent on the runner (`ENOENT`). This update changes no dependency manifests, lockfiles or workflow files; local native validation used the PR branch's noobs 0.0.204.

## Scope

No dependency changes or new persistent metadata fields. The final FFmpeg timestamp is a conservative media-duration estimate and can differ from container duration by a fraction of a second. This prevents recoverable data from being discarded; it does not repair the underlying OBS/noobs failure or a container that fails before its first valid fragment.
