### PR TITLE
Fix clip source navigation after React Table v9 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add the 2560x720 resolution option.
 ### Fixed
+- [Issue 879](https://github.com/aza547/wow-recorder/issues/879) - Restore clip source navigation after the React Table v9 migration.
 
 ## [7.13.0] - 2026-08-27
 ### Changed

--- a/src/renderer/components/Tables/useVideoSelectionTable.tsx
+++ b/src/renderer/components/Tables/useVideoSelectionTable.tsx
@@ -83,6 +83,13 @@ const useVideoSelectionTable = (
   const { category, language, cloudStatus, selectedVideos } = appState;
 
   const getInitialSelection = useCallback(() => {
+    const [selected] = selectedVideos;
+    const selectedParent = getVideoParent(selected?.uniqueId, parentLookupMap);
+
+    if (selectedParent) {
+      return selectedParent;
+    }
+
     if (videoState.length < 1) {
       return null;
     }
@@ -90,7 +97,7 @@ const useVideoSelectionTable = (
     const [first] = videoState;
     const { uniqueId } = first;
     return getVideoParent(uniqueId, parentLookupMap);
-  }, [parentLookupMap, videoState]);
+  }, [parentLookupMap, selectedVideos, videoState]);
 
   /**
    * Tracks if rows are selected or not in the ReactTable component. Initialize


### PR DESCRIPTION
## Summary

- restore clip source navigation after the React Table v9 migration
- initialize row selection from the selected clip's parent recording before falling back to the first row
- document the regression fix under `Unreleased`

Fixes #879

## Validation

- `npx eslint src/renderer/components/Tables/useVideoSelectionTable.tsx`
- `npm run build`
- real Electron E2E with 205 parent recordings: Clips -> Source opened page 2/3, selected parent row 150, centered it in the viewport, preserved the source video and 1-second clip offset, and retained manual pagination
- renderer console and exception capture remained clean during E2E

## Existing repository check failures

- `npm run lint` reports unrelated errors in unchanged files (37 errors, 14 warnings)
- `npm test -- --runInBand` does not execute tests because of existing TypeScript and module-resolution failures; the repository test workflow is currently documented as work in progress
