### PR TITLE
Handle mid-line combat log reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,10 @@
     }
   },
   "jest": {
+    "moduleDirectories": [
+      "node_modules",
+      "<rootDir>/src"
+    ],
     "transform": {
       "\\.(ts|tsx|js|jsx)$": "ts-jest"
     }

--- a/src/__tests__/parser/Basic.test.ts
+++ b/src/__tests__/parser/Basic.test.ts
@@ -1,8 +1,28 @@
 import LogLine from '../../parsing/LogLine';
 import CombatLogWatcher from '../../parsing/CombatLogWatcher';
 
+jest.mock('../../main/util', () => {
+  const nodeFs = jest.requireActual<typeof import('fs')>('fs');
+  const nodePath = jest.requireActual<typeof import('path')>('path');
+
+  return {
+    getFileInfo: async (pathSpec: string) => {
+      const filePath = nodePath.resolve(pathSpec);
+      const stats = await nodeFs.promises.stat(filePath);
+
+      return {
+        name: filePath,
+        size: stats.size,
+        mtime: stats.mtime.getTime(),
+        birthTime: stats.birthtime.getTime(),
+      };
+    },
+    getSortedFiles: async () => [],
+  };
+});
+
 test('Basic Retail', async () => {
-  const combatLogParser = new CombatLogWatcher('', 2);
+  const combatLogParser = new CombatLogWatcher('');
   let promiseResolve: (value: LogLine | PromiseLike<LogLine>) => void;
 
   const testLogLinePromise: Promise<LogLine> = new Promise((resolve) => {
@@ -13,13 +33,15 @@ test('Basic Retail', async () => {
     promiseResolve(line);
   });
 
+  const currYear = new Date().getFullYear();
+
   const arenaMatchStartLine =
     '8/3 22:12:04.000  ARENA_MATCH_START,2547,33,5v5,1';
 
   combatLogParser.handleLogLine(arenaMatchStartLine);
 
   const testLogLine = await testLogLinePromise;
-  const expectedDate = new Date('2025-08-03T22:12:04');
+  const expectedDate = new Date(`${currYear}-08-03T22:12:04`);
 
   expect(testLogLine.date()).toStrictEqual(expectedDate);
   expect(testLogLine.type()).toBe('ARENA_MATCH_START');
@@ -32,9 +54,10 @@ test('Basic Retail', async () => {
 
 test('Date Parsing', async () => {
   // Pre The War Within expansion there were note years or timezones.
+  const currYear = new Date().getFullYear();
   const preTWW = '8/3 22:12:04.000  ARENA_MATCH_START,2547,33,5v5,1';
   const parsedPreTWW = new LogLine(preTWW);
-  const expectedPreTww = new Date('2025-08-03T22:12:04');
+  const expectedPreTww = new Date(`${currYear}-08-03T22:12:04`);
   expect(parsedPreTWW.date()).toStrictEqual(expectedPreTww);
 
   // Year but no TZ.

--- a/src/__tests__/parser/Chunking.test.ts
+++ b/src/__tests__/parser/Chunking.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import CombatLogWatcher from '../../parsing/CombatLogWatcher';
+
+jest.setTimeout(30_000);
+
+jest.mock('../../main/util', () => {
+  const nodeFs = jest.requireActual<typeof import('fs')>('fs');
+  const nodePath = jest.requireActual<typeof import('path')>('path');
+
+  return {
+    getFileInfo: async (pathSpec: string) => {
+      const filePath = nodePath.resolve(pathSpec);
+      const stats = await nodeFs.promises.stat(filePath);
+
+      return {
+        name: filePath,
+        size: stats.size,
+        mtime: stats.mtime.getTime(),
+        birthTime: stats.birthtime.getTime(),
+      };
+    },
+    getSortedFiles: async () => [],
+  };
+});
+
+const LOG_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'tests',
+  'logs',
+  'retail',
+);
+// common VFS chunk sizes depending on the driver
+const CHUNK_SIZES = [4096, 65536, 131072, 1048576];
+
+const loadFixture = (fixture: string): Buffer => {
+  const raw = fs.readFileSync(path.join(LOG_DIR, fixture));
+  return Buffer.from(raw.subarray(0, raw.lastIndexOf(0x0a) + 1));
+};
+
+const toLines = (payload: Buffer): string[] =>
+  payload
+    .toString('utf-8')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s);
+
+const toCrlf = (payload: Buffer): Buffer =>
+  Buffer.from(payload.toString('utf-8').replace(/\n/g, '\r\n'), 'utf-8');
+
+const makeHarness = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wcr-chunking-'));
+  const file = 'WoWCombatLog.txt';
+  const target = path.join(dir, file);
+  const watcher = new CombatLogWatcher(dir);
+  const seen: string[] = [];
+  const original = watcher.handleLogLine.bind(watcher);
+
+  watcher.handleLogLine = (line: string) => {
+    seen.push(line);
+    original(line);
+  };
+
+  fs.writeFileSync(target, '');
+
+  const append = async (data: Buffer) => {
+    fs.appendFileSync(target, data);
+    await (
+      watcher as unknown as { process: (f: string) => Promise<void> }
+    ).process(file);
+  };
+
+  const cleanup = () => fs.rmSync(dir, { recursive: true, force: true });
+  return { seen, append, cleanup };
+};
+
+const deliver = async (
+  payload: Buffer,
+  chunkSize: number,
+): Promise<string[]> => {
+  const { seen, append, cleanup } = makeHarness();
+
+  try {
+    for (let at = 0; at < payload.length; at += chunkSize) {
+      await append(payload.subarray(at, at + chunkSize));
+    }
+  } finally {
+    cleanup();
+  }
+
+  return seen;
+};
+
+describe.each(['raid_wipe.txt', 'mythic_plus.txt'])('%s', (fixture) => {
+  const payload = loadFixture(fixture);
+  const expected = toLines(payload);
+
+  test.each(CHUNK_SIZES)('LF delivered in %i byte chunks', async (size) => {
+    expect(await deliver(payload, size)).toStrictEqual(expected);
+  });
+
+  test.each(CHUNK_SIZES)('CRLF delivered in %i byte chunks', async (size) => {
+    expect(await deliver(toCrlf(payload), size)).toStrictEqual(expected);
+  });
+});
+
+test('holds back a partial trailing line until its newline arrives', async () => {
+  const payload = loadFixture('raid_wipe.txt');
+  const expected = toLines(payload);
+  const cut = payload.lastIndexOf(0x0a, payload.length - 2) + 11;
+  const { seen, append, cleanup } = makeHarness();
+
+  try {
+    await append(payload.subarray(0, cut));
+    expect(seen).toStrictEqual(expected.slice(0, -1));
+
+    await append(payload.subarray(cut));
+    expect(seen).toStrictEqual(expected);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a malformed line is logged and does not stop later lines', async () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  try {
+    const payload = loadFixture('raid_wipe.txt');
+    let offset = 0;
+
+    for (let i = 0; i < 100; i++) {
+      offset = payload.indexOf(0x0a, offset) + 1;
+    }
+
+    const bad = Buffer.from('8/3 22:12:05.000  )0000000141,junk\n', 'utf-8');
+
+    const spliced = Buffer.concat([
+      payload.subarray(0, offset),
+      bad,
+      payload.subarray(offset),
+    ]);
+
+    const seen = await deliver(spliced, 65536);
+
+    expect(seen).toStrictEqual(toLines(spliced));
+    expect(errorSpy).toHaveBeenCalled();
+  } finally {
+    errorSpy.mockRestore();
+  }
+});

--- a/src/parsing/CombatLogWatcher.ts
+++ b/src/parsing/CombatLogWatcher.ts
@@ -154,14 +154,25 @@ export default class CombatLogWatcher extends EventEmitter {
       return;
     }
 
-    await this.parseFileChunk(fullPath, bytesToRead, startPosition);
-    this.state[fullPath] = currentInfo;
+    const consumed = await this.parseFileChunk(
+      fullPath,
+      bytesToRead,
+      startPosition,
+    );
+    // for this path, the size represents the bytes parsed in total, not
+    // necessarily the reported fs.stat of the file, which could be from
+    // a partial line chunk write.
+    this.state[fullPath] = { ...currentInfo, size: startPosition + consumed };
   }
 
   /**
    * Parse a chunk of the file of length bytes from a specified position.
    */
-  private async parseFileChunk(file: string, bytes: number, position: number) {
+  private async parseFileChunk(
+    file: string,
+    bytes: number,
+    position: number,
+  ): Promise<number> {
     const buffer = Buffer.alloc(bytes);
     const handle = await open(file, 'r');
     const { bytesRead } = await read(handle, buffer, 0, bytes, position);
@@ -178,15 +189,42 @@ export default class CombatLogWatcher extends EventEmitter {
 
     this.emit('WARCRAFT_RECORDER_LOG_ACTIVITY');
 
-    const lines = buffer
+    // On some platforms (eg, anything VFS based, especially ntfs-3g), the notify can be sent mid-line.
+    // We can't assume that the last data of the read is a completed log line.
+    // Instead, only parse up to the last new line char return how much we parsed
+    // so that the next read can start from that position.
+    const valid = buffer.subarray(0, bytesRead);
+    const newline = valid.lastIndexOf(0x0a); // \n
+
+    if (newline < 0) {
+      return 0;
+    }
+
+    const consumed = newline + 1;
+
+    const lines = valid
+      .subarray(0, consumed)
       .toString('utf-8')
       .split('\n')
       .map((s) => s.trim())
       .filter((s) => s);
 
     lines.forEach((line) => {
-      this.handleLogLine(line);
+      // If parsing the line fails, at least allow the parser to continue.
+      // State could be undefined, but the alternative is that all
+      // log watching is bricked until an app restart.
+      try {
+        this.handleLogLine(line);
+      } catch (error) {
+        console.error(
+          '[CombatLogWatcher] Failed to handle log line:',
+          line,
+          error,
+        );
+      }
     });
+
+    return consumed;
   }
 
   /**

--- a/src/parsing/CombatLogWatcher.ts
+++ b/src/parsing/CombatLogWatcher.ts
@@ -159,14 +159,18 @@ export default class CombatLogWatcher extends EventEmitter {
       bytesToRead,
       startPosition,
     );
-    // for this path, the size represents the bytes parsed in total, not
-    // necessarily the reported fs.stat of the file, which could be from
-    // a partial line chunk write.
     this.state[fullPath] = { ...currentInfo, size: startPosition + consumed };
   }
 
   /**
-   * Parse a chunk of the file of length bytes from a specified position.
+   * Parse a chunk of the file of length bytes from a specified position to the final new line.
+   *
+   * On some platforms (eg, anything VFS based, especially ntfs-3g), the notify can be sent mid-line.
+   * We can't assume that the last data of the read is a completed log line. Instead, only parse
+   * up to the last new line char and return how much we parsed so that the next read can start from
+   * that position.
+   *
+   * @returns consumed bytes
    */
   private async parseFileChunk(
     file: string,
@@ -189,12 +193,9 @@ export default class CombatLogWatcher extends EventEmitter {
 
     this.emit('WARCRAFT_RECORDER_LOG_ACTIVITY');
 
-    // On some platforms (eg, anything VFS based, especially ntfs-3g), the notify can be sent mid-line.
-    // We can't assume that the last data of the read is a completed log line.
-    // Instead, only parse up to the last new line char return how much we parsed
-    // so that the next read can start from that position.
-    const valid = buffer.subarray(0, bytesRead);
-    const newline = valid.lastIndexOf(0x0a); // \n
+    // reduce to the actual data portion of the buffer
+    const populatedSlice = buffer.subarray(0, bytesRead);
+    const newline = populatedSlice.lastIndexOf(0x0a); // \n
 
     if (newline < 0) {
       return 0;
@@ -202,17 +203,16 @@ export default class CombatLogWatcher extends EventEmitter {
 
     const consumed = newline + 1;
 
-    const lines = valid
+    const lines = populatedSlice
       .subarray(0, consumed)
       .toString('utf-8')
-      .split('\n')
+      .split('\n') // CRLF will leave the \r, then removed by the trim()
       .map((s) => s.trim())
       .filter((s) => s);
 
     lines.forEach((line) => {
-      // If parsing the line fails, at least allow the parser to continue.
-      // State could be undefined, but the alternative is that all
-      // log watching is bricked until an app restart.
+      // Dropping a line can leave the activity we're tracking out of sync, but
+      // that beats one bad line killing log watching until the app restarts.
       try {
         this.handleLogLine(line);
       } catch (error) {


### PR DESCRIPTION
# Summary

Combat log watcher hardening to help address [this reported issue on Discord](https://discord.com/channels/1004860808737591326/1542544430651678780).

## TL;DR

- Parse up to the last `\n` in the file. Throw away the rest.
- Update the position marker to be previous + bytes read. Next read starts where it left off.
- Add a unit test for various chunk sizes against existing log files in the repo.
  - Also verifies that both LF and CRLF variations behave the same way, just in case.
- Fix the existing [Basic.test.ts](https://github.com/aza547/wow-recorder/compare/main...sepdotgg:wow-recorder:handle-midline-win?expand=1#diff-4e19aefeef6675c9c9039fe7a11cf147bd21234523a68421818f2b6f2a1cfd65) parser test that was already broken.
- **Want feedback on this one:** Add a try/catch around the line handler so failures don't totally brick parsing until app restart. If it fires, it results in a degraded experience (ie, you might have missed an ENCOUNTER_END or something), but either way it would have been dead. Still logs an error.

## The root cause

The previous combat log watcher/reader assumed that all reads would land on a line ending (`\n`) character. On Windows, this is largely true, since ReadDirectoryChangesW doesn't fire until the entire write completes, and Windows won't update the file's size until that write happens. From the reader's perspective, the write is atomic, even if under the hood it's still laying down bytes in chunks.

On other platforms (potentially network filesystems on Windows as well) this is not guaranteed.

For modern non-FUSE filesystems (btrfs, ext4, modern kernel 7.1 ntfs), this is usually not an issue. Two things mitigate it: Firstly, VFS won't fire the inotify until all chunks have been written and secondly, these filesystems typically chunk in 128KB pages. So unless WoW flushes more than that at a time, _and_ you land an `fs.stat` in the microsecond window between the notify and a subsequent partial chunk, you won't hit the issue.

However, for FUSE based drivers, like the much older `ntfs-3g`, the default is 4KB chunks, and the notify can happen on every chunk write, rather than at the end. And that's the bug.

## The fix

The perfectly efficient correct fix is to work like a traditional tailing library that operates on full lines: Parse up to the last `\n` in the file, buffer the rest, then prepend it to to the next read.

I opted to go with a slightly simpler fix here that's just as correct:

- Parse up to the last `\n` in the file. Throw away the rest.
- Update the position marker to be previous + bytes read.

This results in a small amount of re-reading partial chunks on the aforementioned filesystem (basically just ntfs-3g) above, but avoids some extra complexity that comes with a full tail reader that optimizes for efficiency above all else. The cost is up to 4KB extra per read (but typically far less because you're reading to EoF anyway) + string parsing up to 4KB in memory, which is microseconds. On Windows, it's functionally equivalent, since the remainder is always 0 bytes.