### PR TITLE
Preserve recordings when metadata cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Added
 ### Fixed
+- Preserve recordings when storage retention cannot read their metadata.
 
 ## [7.13.0] - 2026-08-27
 ### Changed

--- a/src/storage/DiskSizeMonitor.ts
+++ b/src/storage/DiskSizeMonitor.ts
@@ -51,12 +51,12 @@ export default class DiskSizeMonitor {
           const metadata = await getMetadataForVideo(file.name);
           const isUnprotected = !(metadata.protected || false);
           return isUnprotected;
-        } catch {
+        } catch (error) {
           console.error(
             '[DiskSizeMonitor] Failed to get metadata for',
             file.name,
+            error,
           );
-          await deleteVideoDisk(file.name);
           return false;
         }
       },


### PR DESCRIPTION
When a storage limit is enabled, `DiskSizeMonitor` currently deletes a recording whenever reading its metadata fails. This happens before the size-based retention decision, so a missing, malformed, or temporarily unreadable JSON file can cause a recording to be deleted even when storage is well below the limit. Its protection status cannot be established in that case.

Skip that recording for the current retention pass and log the underlying error with its path. Existing protection and size-based retention behavior remain unchanged. A permanently unreadable recording will remain on disk and count toward storage usage; separate orphan cleanup is outside this change.

Validation on the local build based on `77dc4c96`:

- 17/17 focused regression cases passed using the production monitor and metadata helpers with an in-memory filesystem. These cover missing/malformed/unreadable metadata below and above the limit, protected recordings, normal retention, legacy metadata, unlimited storage, and recovery on a later pass. Temporary test scripts are not included in this PR.
- Reproduced through the Windows application UI with synthetic videos, real Electron/OBS/FFmpeg, and an isolated profile: creating a clip deleted three recordings with missing, empty, or malformed JSON before the fix, despite a 10 GiB limit and only a few MB of data.
- Repeated after the fix: all recordings were preserved byte-for-byte, including a protected recording whose JSON was held under an exclusive Windows file lock (`EBUSY`). Restoring metadata/releasing the lock brought recordings back into the library; a second clip and retention pass succeeded. Verified clip decoding and playback in the application.
- `npm run build` and `git diff --check` passed.
- `npm run lint` reports the same 37 errors and 14 warnings before and after this change. Targeted ESLint reports the existing `no-explicit-any` on line 14 of `DiskSizeMonitor.ts`.

Full Jest, Python E2E, packaging, live WoW recording, and cloud transfers were not run. The application E2E covers the clipping-to-retention path; above-limit cases are covered by the isolated regression checks.
