### PR TITLE
Fix empty overrun inputs persisting negative values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Added
 ### Fixed
+- [Issue 863](https://github.com/aza547/wow-recorder/issues/863) - Preserve the last valid overrun setting when its input is cleared.
 - Add Nymrissa "World LFR" difficulty.
 
 ## [7.13.2] - 2026-08-30

--- a/src/renderer/PVESettings.tsx
+++ b/src/renderer/PVESettings.tsx
@@ -46,8 +46,6 @@ const PVESettings = (props: IProps) => {
       minRaidDifficulty: config.minRaidDifficulty,
       recordDungeons: config.recordDungeons,
       recordChallengeModes: config.recordChallengeModes,
-      raidOverrun: config.raidOverrun,
-      dungeonOverrun: config.dungeonOverrun,
       recordCurrentRaidEncountersOnly: config.recordCurrentRaidEncountersOnly,
     };
 


### PR DESCRIPTION
Clearing either overrun input uses -1 as a temporary empty value. Both settings were added to the save payload before the validity checks, so clearing a field still persisted -1 and could shorten the recording duration.

Only add the overrun settings through the existing non-negative checks. Clearing a field now preserves its last saved value.

Fixes #863.

Validation:
- Targeted ESLint passed.
- Production build passed on Node.js 24.
- Verified in a real local Electron app with an isolated profile: clearing both inputs, saving 0 and 60, changing another setting while the inputs are empty, reopening settings, and restarting the app. This was checked on the local 7.13.0 build; the changed component is identical to this PR.
- Full lint reports 36 existing errors outside the changed component.

No test files are included.
